### PR TITLE
fix: repair formatting check and normalize line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,30 @@
+# Line-ending normalization.
+#
+# Without this, a Windows checkout with core.autocrlf=true produces CRLF working
+# files while Linux CI produces LF. Prettier is configured with endOfLine: "lf",
+# so the same commit can pass `format:check` on one machine and fail on the
+# other — which is exactly what happened, and it makes local verification
+# untrustworthy.
+#
+# `text=auto eol=lf` stores everything as LF in Git and checks it out as LF
+# everywhere, so every machine and CI see identical bytes (NFAC-REL-004).
+* text=auto eol=lf
+
+# Binary files must never be line-ending converted; doing so corrupts them.
+*.png binary
+*.jpg binary
+*.jpeg binary
+*.gif binary
+*.ico binary
+*.webp binary
+*.avif binary
+*.pdf binary
+*.woff binary
+*.woff2 binary
+*.ttf binary
+*.otf binary
+*.zip binary
+
+# Generated lock file — collapse it in diffs, it is reviewed by version bump
+# rather than line by line.
+package-lock.json linguist-generated=true

--- a/.prettierignore
+++ b/.prettierignore
@@ -18,3 +18,12 @@ public/
 # cosmetic diffs against approved content for no benefit. They are excluded so
 # `npm run format` never rewrites them.
 docs/
+
+# Agent instructions and evaluation scenarios are the same category of document
+# as docs/ — authored policy, not source. Prettier wants to pad the Markdown
+# tables in evaluations.md, which is the same cosmetic churn for no benefit.
+#
+# This was missed originally because .claude/ and the Prettier config arrived on
+# two different branches, so neither branch alone contained both and the check
+# passed on each. It only failed once they met on production.
+.claude/


### PR DESCRIPTION
## Purpose

CI failed on `production` immediately after PR #1 and PR #2 merged, and every open Dependabot pull request inherits the same failure because they branch from `production`.

```
[warn] .claude/skills/following-git-workflow/evaluations.md
Code style issues found in the above file.
```

## Implementation Summary

Two separate causes, both fixed.

**The governance skill files were never covered by `.prettierignore`.** They arrived on `chore/add-git-governance`; the Prettier configuration arrived on `test/e2e-and-quality`. Neither branch alone contained both, so `format:check` passed on each in isolation and failed only once they met on `production`. Each branch was verified; the merged tree was not.

`.claude/` is now excluded for the same reason `docs/` already is — these are authored policy documents, not source. The actual change Prettier wanted was padding a Markdown table in `evaluations.md`: the same cosmetic churn against a document of record that the `docs/` exclusion exists to prevent.

**No `.gitattributes`, with `core.autocrlf=true` locally.** A Windows checkout produces CRLF working files while Linux CI produces LF. With Prettier configured as `endOfLine: "lf"`, the same commit can pass `format:check` on one machine and fail on the other. Locally Prettier reported 93 files; CI reported one. That made local verification untrustworthy, which is a worse problem than the original defect.

`.gitattributes` now sets `* text=auto eol=lf` so every machine and CI check out identical bytes (NFAC-REL-004). Binary types are marked so they are never line-ending converted. `git add --renormalize` produced no content changes, confirming stored blobs were already LF — only checkout behaviour differed.

## Changed Areas

- `.gitattributes` (new)
- `.prettierignore`

## Requirement Traceability

- PRD: Not applicable
- FAC: Not applicable
- NFAC: NFAC-REL-004 (build determinism), NFAC-TEST-001
- UX/UI: Not applicable
- Technical Design: §5.7, §19, §23.2

## Validation

- [x] Formatting check
- [ ] Lint
- [ ] Type check
- [ ] Content validation
- [ ] Unit/component tests
- [ ] Production build
- [ ] E2E tests, when relevant
- [ ] Accessibility checks, when relevant
- [ ] Link checks, when relevant
- [ ] Dependency/security audit, when relevant

### Commands and Results

```text
# Verified in a fresh clone, which reproduces the CI environment exactly
# rather than relying on this Windows working tree.

git clone --branch fix/ci-formatting-check <repo> verify
grep -rlc $'\r' --include='*.ts' --include='*.tsx' --include='*.md' .
# 0 files contain CRLF

prettier --check .
# "All matched files use Prettier code style!"  exit 0
```

The remaining boxes are unchecked because this branch changes no source; the full chain runs in CI on this pull request.

## Visual Evidence

Not applicable — no user-visible change.

## Confidentiality Review

- [x] No credentials or secrets
- [x] No raw AI-session exports
- [x] No internal company URLs
- [x] No private repository content
- [x] No customer or student data
- [x] No unsafe screenshots or restricted evidence
- [x] Public claims and project status are truthful

## Deployment Impact

None directly. It unblocks CI, which is a prerequisite for adding `quality` and `e2e` as required status checks and for trusting any subsequent deployment.

## Rollback

Revert the squash commit. CI returns to failing on `production`.

## Known Limitations

Once this merges, Dependabot PRs #6 (typescript 7.0.2) and #7 (eslint 10.8.0) will get past Formatting and then fail at **Lint** — which is correct and expected. Those are the two versions documented as incompatible in PR #2: `typescript-eslint` refuses TS 7.0, and `eslint-config-next` bundles `eslint-plugin-react`, which calls the `context.getFilename()` API removed in ESLint 10. Both should be closed rather than merged until upstream support lands.

## Merge Authorization

- [ ] Required checks passed
- [ ] Preview verified when applicable — no Vercel project connected yet
- [ ] Review conversations resolved
- [ ] Randi explicitly approved merging this pull request
