### PR TITLE
fix: correct heading structure and block indexing until launch

### DIFF
--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -31,13 +31,34 @@ async function waitUntilRendered(page: Page): Promise<void> {
   await page.waitForLoadState("networkidle");
 }
 
+/**
+ * Rules that block regardless of the impact axe assigns them.
+ *
+ * `page-has-heading-one` is rated *moderate*, so an impact-only filter let a
+ * live page ship with no h1 at all — a direct NFAC-A11Y-003 failure, which is
+ * P0. Impact reflects how badly a rule breaks a page in general; it does not
+ * know which requirements this project treats as launch-blocking.
+ */
+const ALWAYS_BLOCKING_RULES = new Set([
+  "page-has-heading-one",
+  "heading-order",
+  "landmark-one-main",
+  "html-has-lang",
+  "region",
+]);
+
 async function blockingViolations(page: Page): Promise<string[]> {
   const results = await new AxeBuilder({ page })
-    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa"])
+    .withTags(["wcag2a", "wcag2aa", "wcag21a", "wcag21aa", "wcag22aa", "best-practice"])
     .analyze();
 
   return results.violations
-    .filter((violation) => violation.impact === "critical" || violation.impact === "serious")
+    .filter(
+      (violation) =>
+        violation.impact === "critical" ||
+        violation.impact === "serious" ||
+        ALWAYS_BLOCKING_RULES.has(violation.id),
+    )
     .map(
       (violation) =>
         `${violation.id} (${violation.impact}): ${violation.help} — ` +

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -85,3 +85,39 @@ test.describe("security headers (NFAC-SEC-005)", () => {
     expect(headers["permissions-policy"]).toContain("camera=()");
   });
 });
+
+/**
+ * Heading structure and indexing posture.
+ *
+ * Both regressions this guards against reached production: two routes shipped
+ * with no h1, and the site was crawlable while it was an empty shell.
+ */
+test.describe("every public page has exactly one h1 (NFAC-A11Y-003)", () => {
+  const routes = ["/", "/projects", "/this-route-does-not-exist"];
+
+  for (const route of routes) {
+    test(`${route} has exactly one h1`, async ({ page }) => {
+      await page.goto(route);
+
+      await expect(page.locator("h1")).toHaveCount(1);
+    });
+  }
+});
+
+test.describe("pre-launch indexing posture", () => {
+  test("robots.txt disallows crawling while content is Draft", async ({ request }) => {
+    const body = await (await request.get("/robots.txt")).text();
+
+    expect(body).toMatch(/Disallow:\s*\/\s*$/m);
+  });
+
+  test("pages carry noindex, because robots.txt alone does not prevent indexing", async ({
+    page,
+  }) => {
+    await page.goto("/");
+
+    const robots = await page.locator('meta[name="robots"]').getAttribute("content");
+
+    expect(robots).toContain("noindex");
+  });
+});

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { ExperienceSection } from "@/components/sections/experience-section";
 import { HeroSection } from "@/components/sections/hero-section";
 import { ProjectsSection } from "@/components/sections/projects-section";
 import { SkillsSection } from "@/components/sections/skills-section";
+import { getPublishedProfile, getSiteConfig } from "@/domain/content/selectors";
 
 /**
  * Home.
@@ -20,8 +21,19 @@ import { SkillsSection } from "@/components/sections/skills-section";
  * release validation reports as launch-blocking.
  */
 export default function Home() {
+  // The Hero owns the page's h1, but it renders nothing while the profile is
+  // Draft — which left the live homepage with no h1 at all, breaking the
+  // one-primary-heading requirement in NFAC-A11Y-003.
+  //
+  // A visually hidden fallback keeps the document outline valid without
+  // inventing visible content on an otherwise empty page. It uses the owner
+  // name, which is a Confirmed decision (DEC-012), not placeholder text.
+  const hasHeroHeading = getPublishedProfile() !== null;
+
   return (
     <>
+      {hasHeroHeading ? null : <h1 className="sr-only">{getSiteConfig().ownerName}</h1>}
+
       <HeroSection />
       <AboutSection />
       <ProjectsSection />

--- a/src/app/projects/page.tsx
+++ b/src/app/projects/page.tsx
@@ -29,8 +29,10 @@ export default function ProjectsPage() {
       <div className="flex flex-col gap-10">
         <SectionHeader
           heading="Projects"
-          level={2}
-          headingClassName="text-4xl sm:text-5xl"
+          // The page's primary heading, so structurally an h1 (NFAC-A11Y-003).
+          // This previously rendered as an h2 sized like an h1, which left the
+          // route with no h1 at all.
+          level={1}
           description={
             <>
               <p>
@@ -54,6 +56,7 @@ export default function ProjectsPage() {
                 <ProjectCard
                   project={project}
                   technologyNames={getTechnologyNames(project.technologyIds)}
+                  headingLevel={2}
                 />
               </li>
             ))}
@@ -67,9 +70,9 @@ export default function ProjectsPage() {
            */
           <div className="flex flex-col items-start gap-6 rounded-(--radius-card) border border-border bg-surface p-8 sm:p-12">
             <div className="flex flex-col gap-3">
-              <h3 className="text-2xl font-semibold text-text-primary">
+              <h2 className="text-2xl font-semibold text-text-primary">
                 Case studies are being prepared
-              </h3>
+              </h2>
               <p className="max-w-(--spacing-prose) text-text-secondary">
                 Published project case studies will appear here. In the meantime, my resume and
                 contact details are available.

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,16 +1,34 @@
 import type { MetadataRoute } from "next";
+import { isPubliclyLaunchReady } from "@/domain/content/selectors";
 import { absoluteUrl } from "@/lib/environment";
 
 /**
  * Robots (TD 11.8).
  *
- * Public pages are crawlable. There is deliberately no disallow list for
- * unpublished content: those routes are never generated, so there is nothing
- * to disallow. Listing them would be worse than useless — a disallow entry
- * publishes the existence of the very paths it is trying to hide, which is
- * exactly what DEC-047 forbids.
+ * Once the site is launch-ready, public pages are crawlable. There is
+ * deliberately no disallow list for unpublished content: those routes are never
+ * generated, so there is nothing to disallow. Listing them would be worse than
+ * useless — a disallow entry publishes the existence of the very paths it is
+ * trying to hide, which is exactly what DEC-047 forbids.
+ *
+ * Before launch, crawling is refused outright. The deployment is publicly
+ * reachable from the moment Vercel connects, and an incomplete portfolio being
+ * indexed and cached works directly against the product goal (PRD 1.2): a
+ * recruiter finding a near-empty page is worse than finding nothing.
+ *
+ * This reverses itself automatically when the launch content is published, so
+ * it cannot be forgotten in either direction.
  */
 export default function robots(): MetadataRoute.Robots {
+  if (!isPubliclyLaunchReady()) {
+    return {
+      rules: {
+        userAgent: "*",
+        disallow: "/",
+      },
+    };
+  }
+
   return {
     rules: {
       userAgent: "*",

--- a/src/components/project/project-card.tsx
+++ b/src/components/project/project-card.tsx
@@ -10,6 +10,15 @@ interface ProjectCardProps {
   readonly project: ProjectCaseStudy;
   /** Canonical technology names, resolved by the caller. */
   readonly technologyNames: readonly string[];
+  /**
+   * Heading level for the card title.
+   *
+   * The card appears under an h1 on the Projects Index and under an h2 section
+   * heading on the homepage, so its own level depends on where it sits. A
+   * hardcoded level skips a heading level in one of the two places, which
+   * axe's heading-order rule flags and screen-reader users navigate by.
+   */
+  readonly headingLevel?: 2 | 3;
 }
 
 const PROJECT_TYPE_LABEL: Record<ProjectCaseStudy["projectType"], string> = {
@@ -27,9 +36,10 @@ const PROJECT_TYPE_LABEL: Record<ProjectCaseStudy["projectType"], string> = {
  * card clickable, which keeps the accessible name to the project title while
  * preserving the large click target.
  */
-export function ProjectCard({ project, technologyNames }: ProjectCardProps) {
+export function ProjectCard({ project, technologyNames, headingLevel = 3 }: ProjectCardProps) {
   const [firstMediaId] = project.mediaAssetIds ?? [];
   const visual = getPublishedMediaAsset(firstMediaId);
+  const Heading = `h${headingLevel}` as const;
 
   return (
     <article className="group relative flex flex-col gap-4 rounded-(--radius-card) border border-border bg-surface p-6 transition-colors hover:border-accent">
@@ -49,14 +59,14 @@ export function ProjectCard({ project, technologyNames }: ProjectCardProps) {
         <StatusBadge status={project.deliveryStatus} />
       </div>
 
-      <h3 className="text-xl font-semibold text-text-primary">
+      <Heading className="text-xl font-semibold text-text-primary">
         <Link
           href={ROUTES.projectDetail(project.slug)}
           className="after:absolute after:inset-0 after:content-[''] group-hover:text-accent"
         >
           {project.title}
         </Link>
-      </h3>
+      </Heading>
 
       <p className="text-text-secondary">{project.summary}</p>
 

--- a/src/components/ui/section-header.tsx
+++ b/src/components/ui/section-header.tsx
@@ -4,12 +4,17 @@ import type { ReactNode } from "react";
  * Heading levels this component may render.
  *
  * Configurable because NFAC-A11Y-003 requires a logical heading hierarchy with
- * one h1 per page. A section header inside the homepage is an h2; the same
- * component inside a case study subsection is an h3. Choosing a level for
- * visual size instead of structure is exactly what UX 15.2 forbids, so size is
+ * one h1 per page. A page's primary heading is an h1; a section within it is an
+ * h2; a subsection inside a case study is an h3. Choosing a level for visual
+ * size instead of structure is exactly what UX 15.2 forbids, so size is
  * controlled separately through className.
+ *
+ * Level 1 was originally omitted here, which forced the Projects Index to
+ * render its primary heading as an h2 styled at h1 size — the same
+ * structure-for-appearance mistake, just inverted. The type now permits h1 so
+ * a page-level heading can be structurally correct.
  */
-export type HeadingLevel = 2 | 3 | 4;
+export type HeadingLevel = 1 | 2 | 3 | 4;
 
 interface SectionHeaderProps {
   readonly heading: string;
@@ -24,6 +29,7 @@ interface SectionHeaderProps {
 }
 
 const DEFAULT_HEADING_SIZE: Record<HeadingLevel, string> = {
+  1: "text-4xl sm:text-5xl",
   2: "text-3xl sm:text-4xl",
   3: "text-2xl sm:text-3xl",
   4: "text-xl sm:text-2xl",

--- a/src/domain/content/selectors.ts
+++ b/src/domain/content/selectors.ts
@@ -79,6 +79,26 @@ export function getPublishedProfile(): ProfessionalProfile | null {
   return isPubliclyEligible(profile) ? profile : null;
 }
 
+/**
+ * Whether the site has enough approved content to be worth discovering.
+ *
+ * Search engines are kept out until this is true. An incomplete portfolio
+ * getting indexed and cached actively works against the product goal — a
+ * recruiter finding a near-empty page is worse than finding nothing — and
+ * NFAC-SEO-002 only asks that pages *intended for discovery* be crawlable.
+ *
+ * Deliberately derived from content state rather than an environment flag or a
+ * hardcoded boolean: it flips itself the moment the launch content is
+ * published, so nobody has to remember to turn indexing on, and nobody can
+ * turn it on early by accident.
+ *
+ * The threshold mirrors the launch rule in DEC-030 and FAC-HOME-004: a
+ * Published profile and at least two Published projects.
+ */
+export function isPubliclyLaunchReady(): boolean {
+  return getPublishedProfile() !== null && getPublishedProjects().length >= 2;
+}
+
 /** Published Work Experience, most recent first (UX 7.6). */
 export function getPublishedExperience(): readonly WorkExperience[] {
   return experience

--- a/src/domain/metadata/build-metadata.ts
+++ b/src/domain/metadata/build-metadata.ts
@@ -1,5 +1,5 @@
 import type { Metadata } from "next";
-import { siteConfig } from "@/content/site";
+import { getSiteConfig, isPubliclyLaunchReady } from "@/domain/content/selectors";
 import type { ProjectCaseStudy } from "@/domain/content/schemas";
 import { absoluteUrl, getSiteUrl } from "@/lib/environment";
 import { ROUTES } from "@/lib/constants";
@@ -18,10 +18,27 @@ import { ROUTES } from "@/lib/constants";
 
 /** Metadata shared by every route. */
 export function buildRootMetadata(): Metadata {
+  const siteConfig = getSiteConfig();
   const siteUrl = getSiteUrl();
 
   return {
     metadataBase: new URL(siteUrl),
+
+    /*
+     * Pre-launch, every page carries noindex in addition to the robots.txt
+     * disallow.
+     *
+     * The two are not redundant. robots.txt asks a crawler not to *fetch* a
+     * page; a URL linked from somewhere else can still be indexed without ever
+     * being fetched, showing up as a bare result. The meta directive is what
+     * actually keeps it out of the index.
+     *
+     * Flips automatically once the launch content is published.
+     */
+    robots: isPubliclyLaunchReady()
+      ? { index: true, follow: true }
+      : { index: false, follow: false, nocache: true },
+
     title: {
       default: siteConfig.defaultTitle,
       template: siteConfig.titleTemplate,
@@ -51,6 +68,7 @@ export function buildRootMetadata(): Metadata {
 
 /** Metadata for the Projects Index. */
 export function buildProjectsIndexMetadata(): Metadata {
+  const siteConfig = getSiteConfig();
   const description =
     "Selected project case studies covering the problem, my responsibility, the technical " +
     "approach, and how each result was verified.";
@@ -75,6 +93,7 @@ export function buildProjectsIndexMetadata(): Metadata {
  * unpublished project can never reach this function.
  */
 export function buildProjectMetadata(project: ProjectCaseStudy): Metadata {
+  const siteConfig = getSiteConfig();
   const canonical = ROUTES.projectDetail(project.slug);
 
   return {

--- a/tests/domain/launch-readiness.test.ts
+++ b/tests/domain/launch-readiness.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it, vi } from "vitest";
+
+/**
+ * Launch readiness drives whether search engines are allowed in. Getting it
+ * wrong in either direction is costly: too permissive and an incomplete
+ * portfolio is indexed and cached against the product goal; too strict and a
+ * finished portfolio stays invisible.
+ */
+
+const publishedProject = {
+  id: "p-1",
+  slug: "one",
+  publicationStatus: "published",
+  confidentialityClass: "public",
+  featured: true,
+  featuredPriority: 1,
+  updatedAt: "2026-01-01",
+  title: "One",
+};
+
+function projectSet(count: number) {
+  return Array.from({ length: count }, (_, index) => ({
+    ...publishedProject,
+    id: `p-${index}`,
+    slug: `slug-${index}`,
+    featuredPriority: index + 1,
+  }));
+}
+
+describe("isPubliclyLaunchReady", () => {
+  it("is false while the profile is Draft, even with enough projects", async () => {
+    vi.resetModules();
+    vi.doMock("@/content/profile", () => ({
+      profile: { id: "profile-a", publicationStatus: "draft" },
+    }));
+    vi.doMock("@/content/projects", () => ({ projects: projectSet(2) }));
+
+    const { isPubliclyLaunchReady } = await import("@/domain/content/selectors");
+
+    expect(isPubliclyLaunchReady()).toBe(false);
+  });
+
+  it("is false with a published profile but fewer than two projects (DEC-030)", async () => {
+    vi.resetModules();
+    vi.doMock("@/content/profile", () => ({
+      profile: { id: "profile-a", publicationStatus: "published" },
+    }));
+    vi.doMock("@/content/projects", () => ({ projects: projectSet(1) }));
+
+    const { isPubliclyLaunchReady } = await import("@/domain/content/selectors");
+
+    expect(isPubliclyLaunchReady()).toBe(false);
+  });
+
+  it("is true with a published profile and two published projects", async () => {
+    vi.resetModules();
+    vi.doMock("@/content/profile", () => ({
+      profile: { id: "profile-a", publicationStatus: "published" },
+    }));
+    vi.doMock("@/content/projects", () => ({ projects: projectSet(2) }));
+
+    const { isPubliclyLaunchReady } = await import("@/domain/content/selectors");
+
+    expect(isPubliclyLaunchReady()).toBe(true);
+  });
+
+  it("is false for the real content set today", async () => {
+    // doMock registrations survive resetModules, so the mocks from the tests
+    // above must be explicitly removed or this reads mocked content and
+    // silently passes for the wrong reason.
+    vi.doUnmock("@/content/profile");
+    vi.doUnmock("@/content/projects");
+    vi.resetModules();
+
+    const { isPubliclyLaunchReady } = await import("@/domain/content/selectors");
+
+    // Everything is Draft, so the site must not be indexable. This flips on its
+    // own at P30 — deliberately, so nobody has to remember to enable indexing.
+    expect(isPubliclyLaunchReady()).toBe(false);
+  });
+});


### PR DESCRIPTION
## Purpose

Two defects found by verifying the live Vercel deployment, neither caught by any existing test.

1. **Two routes shipped with no `<h1>`** — a direct NFAC-A11Y-003 failure, which is P0.
2. **The site was fully crawlable while it is an empty shell** — an incomplete portfolio getting indexed works directly against the product goal (PRD §1.2).

## Heading structure

`/projects` rendered its primary heading as an `h2` styled at `h1` size. That is the structure-for-appearance mistake UX §15.2 forbids, just inverted — and it was **permanent**, not a Draft artifact. It would still have been wrong after P30.

The root cause was `SectionHeader`'s `HeadingLevel` type omitting `1`, so an `h1` was not expressible at all. The type now permits it.

The homepage `h1` lives in `HeroSection`, which renders nothing while the profile is Draft. A visually hidden fallback keeps the document outline valid without inventing visible content, using the owner name — a Confirmed decision (DEC-012), not placeholder text. It disappears once the Hero renders.

**Fixing the first exposed a second.** With `/projects` correctly starting at `h1`, its card titles skipped to `h3`. `ProjectCard` hardcoded `h3` — correct beneath the homepage's `h2` section heading, wrong beneath a page `h1`. The level is now a prop. This would otherwise have surfaced only at P30, when projects publish and cards actually render.

### Why the accessibility gate missed it

axe rates `page-has-heading-one` and `heading-order` as **moderate**, and the scan filtered to critical and serious only. Impact reflects how badly a rule breaks a page in general; it does not know which requirements this project treats as launch-blocking.

The scan now also blocks on an explicit rule list — heading structure, landmarks, language — and enables the `best-practice` tag so those rules run at all. That change immediately caught the `heading-order` violation above, which is the point.

## Indexing

`robots.txt` now disallows crawling and every page carries `noindex`.

The two are **not redundant**: `robots.txt` asks a crawler not to *fetch* a page, but a URL linked from elsewhere can still be indexed without ever being fetched, appearing as a bare result. The meta directive is what actually keeps it out of the index.

Both derive from content state via `isPubliclyLaunchReady()` — a Published profile and at least two Published projects, matching DEC-030 and FAC-HOME-004 — rather than an environment flag or hardcoded boolean. It flips itself when launch content publishes, so nobody has to remember to enable indexing, and nobody can enable it early by accident.

## Changed Areas

- `src/components/ui/section-header.tsx` — `HeadingLevel` now includes `1`
- `src/app/projects/page.tsx` — `h1` primary heading; empty-state heading `h3` → `h2`
- `src/app/page.tsx` — visually hidden `h1` fallback
- `src/components/project/project-card.tsx` — configurable heading level
- `src/app/robots.ts`, `src/domain/metadata/build-metadata.ts` — pre-launch indexing posture
- `src/domain/content/selectors.ts` — `isPubliclyLaunchReady()`
- `e2e/accessibility.spec.ts`, `e2e/navigation.spec.ts`, `tests/domain/launch-readiness.test.ts`

## Requirement Traceability

- PRD: §1.2
- FAC: FAC-HOME-004, FAC-PROJECTS-001
- NFAC: **NFAC-A11Y-001, NFAC-A11Y-003 (P0)**, NFAC-SEO-002
- UX/UI: §15.2
- Technical Design: §11.8, §12, §15.4

## Validation

- [x] Formatting check
- [x] Lint
- [x] Type check
- [x] Content validation
- [x] Unit/component tests
- [x] Production build
- [x] E2E tests, when relevant
- [x] Accessibility checks, when relevant
- [ ] Link checks, when relevant
- [ ] Dependency/security audit, when relevant

### Commands and Results

```text
npm run check
# exit 0 — full chain, build emits 7 routes

npx vitest run
# 255 tests passed, 19 files

npx playwright test --project=chromium
# accessibility + navigation: 20 passed
# the tightened gate caught heading-order on /projects before this fix,
# and passes after it

# Against a real production build:
/          h1=1
/projects  h1=1
/nope      h1=1

robots.txt  -> "User-Agent: *  Disallow: /"
meta robots -> content="noindex, nofollow, nocache"
```

`check:links` and `audit:prod` are release-audit steps requiring a deployed URL.

## Visual Evidence

No visible change. The homepage `h1` fallback is `sr-only`; the `/projects` heading keeps its existing size, now carried by the correct element.

## Confidentiality Review

- [x] No credentials or secrets
- [x] No raw AI-session exports
- [x] No internal company URLs
- [x] No private repository content
- [x] No customer or student data
- [x] No unsafe screenshots or restricted evidence
- [x] Public claims and project status are truthful

## Deployment Impact

On deploy, the live site stops being indexable and gains a valid heading outline. Indexing re-enables automatically at P30 when launch content publishes — no manual step, and no way to forget it.

## Rollback

Revert the squash commit. The site becomes crawlable again and the two routes lose their `h1`.

## Known Limitations

- If the site is deployed publicly for an extended period before P30 and a crawler already indexed it, `noindex` requests removal but removal is not instant.
- `isPubliclyLaunchReady()` uses the DEC-030 launch threshold. Publishing a profile and two projects enables indexing even if other content is still Draft — intentional, since that is the approved definition of launch-ready.

## Merge Authorization

- [ ] Required checks passed
- [ ] Preview verified when applicable
- [ ] Review conversations resolved
- [ ] Randi explicitly approved merging this pull request
