### PR TITLE
chore: hold back three dependencies with known incompatibilities

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,35 @@ updates:
       prefix: chore
       include: scope
 
+    # Three packages are held back deliberately. Without these rules Dependabot
+    # reopens the same pull requests every Monday, each failing CI for a known
+    # reason — and a recurring red check trains everyone to stop reading them.
+    #
+    # These are version ceilings, not permanent exclusions. Patch and minor
+    # updates within the allowed range, including security fixes, still come
+    # through. Revisit when the upstream blocker in each note is resolved.
+    ignore:
+      # TypeScript 7 is the ground-up native compiler rewrite. tsc itself passes
+      # cleanly; it is the lint integration that breaks. typescript-eslint
+      # refuses to load against it — "typescript-eslint does not support TS 7.0"
+      # — and tracks support for TS >= 7.1 in typescript-eslint issue 10940.
+      - dependency-name: typescript
+        versions: [">=7.0.0"]
+
+      # ESLint 10 removed context.getFilename(). eslint-config-next bundles
+      # eslint-plugin-react, which still calls it, so every lint run crashes
+      # with "contextOrFilename.getFilename is not a function". ESLint 9 is also
+      # what the create-next-app template selects for this Next.js version.
+      - dependency-name: eslint
+        versions: [">=10.0.0"]
+
+      # @types/node must track the pinned runtime rather than lead it. Node is
+      # fixed at 24 LTS via .nvmrc, .node-version, and the package.json engines
+      # range, so types describing Node 26 APIs would describe a runtime this
+      # project does not have. Lift this together with the Node major.
+      - dependency-name: "@types/node"
+        versions: [">=25.0.0"]
+
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Purpose

Dependabot reopens closed pull requests on its next scheduled run, so closing #6, #7, and #8 only helps until Monday. Three packages would return every week and fail CI for reasons already understood — and a recurring red check trains everyone to stop reading them.

## Implementation Summary

Adds an `ignore` block to the npm ecosystem in `.github/dependabot.yml` holding back three packages.

These are **version ceilings, not exclusions**. Each sits exactly one major above the current pin, so patch and minor updates — including security fixes — still come through normally.

| Package | Pinned | Held below | Blocker |
|---|---|---|---|
| `typescript` | 6.0.3 | `7.0.0` | `typescript-eslint` refuses to load against TS 7; tracks support for TS ≥ 7.1 upstream. `tsc` itself passes — it is the lint integration that breaks. |
| `eslint` | 9.39.5 | `10.0.0` | ESLint 10 removed `context.getFilename()`, which `eslint-plugin-react` still calls. `eslint-config-next` bundles that plugin, so every lint run crashes. |
| `@types/node` | 24.13.3 | `25.0.0` | Types must track the pinned runtime, not lead it. Node is fixed at 24 LTS in `.nvmrc`, `.node-version`, and the `engines` range. |

Each rule carries its specific upstream blocker in a comment, so a future reader can tell whether it is still needed rather than guessing. The TypeScript and ESLint ceilings lift when upstream support lands; the `@types/node` one lifts with the Node major.

**GitHub Actions updates are deliberately not restricted.** PRs #3, #4, and #5 bump `checkout`, `setup-node`, and `upload-artifact` and should be evaluated normally.

## Changed Areas

- `.github/dependabot.yml`

## Requirement Traceability

- PRD: Not applicable
- FAC: Not applicable
- NFAC: NFAC-SEC-004 (dependency vulnerability threshold), NFAC-MAINT-005 (dependency discipline), NFAC-REL-004
- UX/UI: Not applicable
- Technical Design: §22.4

## Validation

- [ ] Formatting check
- [ ] Lint
- [ ] Type check
- [ ] Content validation
- [ ] Unit/component tests
- [ ] Production build
- [ ] E2E tests, when relevant
- [ ] Accessibility checks, when relevant
- [ ] Link checks, when relevant
- [ ] Dependency/security audit, when relevant

### Commands and Results

```text
# Configuration-only change; no source is touched. The full chain runs in CI
# on this pull request. Boxes left unchecked rather than claimed.

# Verification actually performed:

# Structure: no tabs, all required keys present
node -e "<structural check>"
# structure OK, 61 lines

# Each ceiling is exactly one major above the current pin, so patch and
# minor updates still flow:
typescript     pinned=6.0.3    ignored=>=7.0.0
eslint         pinned=9.39.5   ignored=>=10.0.0
@types/node    pinned=24.13.3  ignored=>=25.0.0
```

## Visual Evidence

Not applicable.

## Confidentiality Review

- [x] No credentials or secrets
- [x] No raw AI-session exports
- [x] No internal company URLs
- [x] No private repository content
- [x] No customer or student data
- [x] No unsafe screenshots or restricted evidence
- [x] Public claims and project status are truthful

## Deployment Impact

None. Dependabot configuration only.

## Rollback

Revert the squash commit. The three packages resume proposing major upgrades weekly.

## Known Limitations

- An ignore rule suppresses **all** updates matching the range, including a security advisory affecting only the ignored majors. Since the project stays on the lower major, advisories for that line still surface normally — but this is worth re-checking whenever a ceiling is lifted.
- Ceilings need periodic review. Nothing automatically notices when `typescript-eslint` ships TS 7 support; the comments name the blocker so the check is cheap.

## Merge Authorization

- [ ] Required checks passed
- [ ] Preview verified when applicable
- [ ] Review conversations resolved
- [ ] Randi explicitly approved merging this pull request
