### PR TITLE
docs: record branch protection plan limitation

### DIFF
--- a/docs/governance/github-configuration.md
+++ b/docs/governance/github-configuration.md
@@ -96,6 +96,39 @@ Default squash message recommendation:
 
 ## 4. Protect `production`
 
+> **Plan limitation — not configurable while the repository is private.**
+>
+> Branch rulesets and branch protection are unavailable for private
+> repositories on the GitHub Free plan. Both the rulesets API and the legacy
+> branch-protection API return:
+>
+> ```text
+> 403: Upgrade to GitHub Pro or make this repository public
+>      to enable this feature.
+> ```
+>
+> This section was written assuming the feature was available. It is not, so
+> the checklist item moves to the public-visibility step in section 9 rather
+> than being treated as an outstanding configuration mistake.
+>
+> **Until then, nothing technically prevents a direct push to `production`.**
+> The prohibition in `git-workflow.md` section 8 is policy, not enforcement.
+> The practical risk is limited — there is a single contributor, and CI still
+> runs on every pull request — but the gap is real and should not be
+> misremembered as protection that exists.
+>
+> Three ways to resolve it:
+>
+> 1. **Wait for public visibility.** Protection becomes available at no cost
+>    the moment the repository is made public, which section 1 already plans
+>    before job applications. Recommended.
+> 2. **Upgrade to GitHub Pro.** Protection immediately, and it persists after
+>    the repository becomes public.
+> 3. Making the repository public early is **not** an acceptable workaround.
+>    It would bypass the confidentiality gate in section 9.
+>
+> Configure the ruleset below as soon as the feature becomes available.
+
 Create a branch ruleset:
 
 ```text
@@ -185,6 +218,18 @@ Enable every feature available under the current GitHub plan:
 - Push protection
 - Code scanning
 - Private vulnerability reporting after the repository becomes public
+
+> **Several of these are also plan-restricted on a private repository.**
+>
+> Secret scanning, push protection, and code scanning are GitHub Advanced
+> Security features and are generally unavailable on a private repository on
+> the Free plan. Dependabot version updates work regardless — the configuration
+> in `.github/dependabot.yml` is already opening pull requests — but Dependabot
+> *alerts* are a separate toggle.
+>
+> Enable whatever the plan currently offers, and re-check this list when the
+> repository becomes public, at which point the remainder become available at
+> no cost. Do not record an unavailable feature as enabled.
 
 ### Dependabot
 
@@ -283,6 +328,23 @@ Before switching the repository from Private to Public:
 
 Once a repository becomes public, hiding a file from the current branch does
 not remove it from previous Git history.
+
+### Immediately after switching to Public
+
+These become available at no cost the moment visibility changes, and are easy
+to forget precisely because the switch feels like the finish line:
+
+- [ ] Create the `Protect production` ruleset from section 4 — this is the item
+      deferred by the plan limitation, and the repository has been running
+      without enforced branch protection until now
+- [ ] Add `quality` and `e2e` as required status checks
+- [ ] Enable secret scanning and push protection
+- [ ] Enable code scanning
+- [ ] Enable private vulnerability reporting
+
+Enabling protection *after* going public leaves a window where the repository
+is both public and unprotected. Do this first, before announcing the URL or
+sending it with any job application.
 
 ---
 

--- a/docs/governance/setup-checklist.md
+++ b/docs/governance/setup-checklist.md
@@ -5,12 +5,16 @@ from the working tree and Git history. Items marked *interface* must be
 confirmed in the GitHub or Vercel web interface and cannot be verified from the
 repository.
 
+Items marked **blocked** are not available on the current GitHub plan while the
+repository is private. They are not outstanding mistakes — see
+`github-configuration.md` section 4.
+
 ## Local and GitHub Branch
 
 - [x] Create repository `randifajar/developer-portfolio`
 - [x] Use `production` as the local branch
 - [x] Push `production`
-- [ ] Set `production` as GitHub default — *interface*
+- [x] Set `production` as GitHub default — verified via API
 - [x] Remove stale `main` references
 - [x] Delete remote `main` only after verification — not applicable; no `main`
       branch has ever existed on this remote
@@ -25,45 +29,70 @@ repository.
 
 ## Pull Requests and Merge
 
-*All items in this section are configured in the GitHub interface.*
+*Configured in the GitHub interface. Verified via API 2026-08-04.*
 
-- [ ] Enable squash merge only
-- [ ] Enable automatic branch deletion
-- [ ] Disable merge commits
-- [ ] Disable rebase merge
+- [x] Enable squash merge only
+- [x] Enable automatic branch deletion
+- [x] Disable merge commits
+- [x] Disable rebase merge
+
+The eleven pull requests merged before this was configured landed as merge
+commits. That history is left as it is; rewriting it would be more disruptive
+than the inconsistency is worth.
 
 ## Ruleset
 
-*All items in this section are configured in the GitHub interface.*
+**Blocked — branch rulesets and branch protection are unavailable for private
+repositories on the GitHub Free plan.** Both the rulesets API and the legacy
+branch-protection API return `403: Upgrade to GitHub Pro or make this repository
+public`.
 
-- [ ] Create `Protect production`
-- [ ] Require pull requests
-- [ ] Require conversation resolution
-- [ ] Require linear history
-- [ ] Block force pushes
-- [ ] Block deletion
-- [ ] Require branch up to date
-- [ ] Set approvals to zero for solo ownership
-- [ ] Add status checks after workflows exist
+Until this is resolved, nothing technically prevents a direct push to
+`production`. The prohibition in `git-workflow.md` section 8 is policy, not
+enforcement.
+
+Complete these **immediately** after switching the repository to Public, before
+sending the URL with any job application:
+
+- [ ] Create `Protect production` — *blocked*
+- [ ] Require pull requests — *blocked*
+- [ ] Require conversation resolution — *blocked*
+- [ ] Require linear history — *blocked*
+- [ ] Block force pushes — *blocked*
+- [ ] Block deletion — *blocked*
+- [ ] Require branch up to date — *blocked*
+- [ ] Set approvals to zero for solo ownership — *blocked*
+- [ ] Add status checks `quality` and `e2e` — *blocked*; both job names are
+      already known to GitHub from repeated green runs, so they will appear in
+      the picker as soon as rulesets are available
 
 ## Security
 
-*All items in this section are configured in the GitHub interface.*
+*Configured in the GitHub interface. Several are also plan-restricted while the
+repository is private.*
 
 - [ ] Enable dependency graph
 - [ ] Enable Dependabot alerts
-- [ ] Enable Dependabot security updates
-- [ ] Enable secret scanning when available
-- [ ] Enable push protection when available
-- [ ] Enable code scanning after code exists
-- [ ] Restrict default Actions token permissions
+- [x] Enable Dependabot security updates — version updates confirmed working;
+      `.github/dependabot.yml` is opening pull requests
+- [ ] Enable secret scanning when available — *likely blocked while private*
+- [ ] Enable push protection when available — *likely blocked while private*
+- [ ] Enable code scanning after code exists — *likely blocked while private*
+- [ ] Restrict default Actions token permissions — the CI workflow already
+      declares `permissions: contents: read` at workflow level, so this setting
+      is defence in depth rather than the only control
 
 ## Vercel
 
-*All items in this section are configured in the Vercel interface.*
+*Configured in the Vercel interface. Verified against the live deployment
+2026-08-04.*
 
-- [ ] Connect the GitHub repository
-- [ ] Set Production Branch to `production`
-- [ ] Confirm task branches create Preview Deployments
-- [ ] Confirm merge to `production` creates Production Deployment
-- [ ] Set production `SITE_URL`
+- [x] Connect the GitHub repository
+- [x] Set Production Branch to `production` — merges to `production` deploy
+      automatically, confirmed
+- [ ] Confirm task branches create Preview Deployments — not yet observed; the
+      next task branch will show whether previews are enabled
+- [x] Confirm merge to `production` creates Production Deployment
+- [x] Set production `SITE_URL` — confirmed live: canonical links, sitemap, and
+      Open Graph tags all use the production domain rather than the localhost
+      fallback


### PR DESCRIPTION
## Purpose

Verifying the GitHub configuration against the live repository showed that section 4 asks for something the current plan cannot provide:

```
403: Upgrade to GitHub Pro or make this repository public
     to enable this feature.
```

Branch rulesets and branch protection are unavailable for **private** repositories on GitHub Free. Both the rulesets API and the legacy branch-protection API refuse.

The governance package was written assuming the feature was available, so the checklist read as an outstanding configuration mistake when it is in fact a plan limitation. Left uncorrected, the next reader either wastes time hunting for a setting that is not there, or — worse — assumes branch protection exists when it does not.

## Implementation Summary

**Section 4** now states the limitation up front, and states plainly that nothing currently prevents a direct push to `production`: the prohibition in `git-workflow.md` §8 is policy, not enforcement. The practical risk is limited to a single contributor with CI on every pull request, but a gap recorded as protection is worse than a gap recorded as a gap.

Three resolutions are listed, with making the repository public early explicitly rejected — it would bypass the confidentiality gate in §9.

**Section 9** gains an "Immediately after switching to Public" subsection holding the deferred ruleset items. Enabling protection *after* going public leaves a window where the repository is both public and unprotected, and the visibility switch feels like a finish line, which is exactly when this gets forgotten. The instruction is to do it before sending the URL with any job application.

**Section 6** gets the same treatment. Secret scanning, push protection, and code scanning are Advanced Security features and are also generally unavailable on a private Free repository. Dependabot version updates work regardless — observably, it has been opening pull requests — but alerts are a separate toggle. The instruction is to enable whatever the plan offers and never record an unavailable feature as enabled.

**The checklist** is brought up to date with what has actually been verified rather than what was assumed.

## Verified state now recorded

| Item | Status |
|---|---|
| Default branch `production` | confirmed via API |
| Squash merge only, auto-delete, no merge/rebase commits | confirmed via API |
| Vercel Production Branch → `production` | confirmed by live deployment |
| `SITE_URL` | confirmed — canonical, sitemap, and OG tags use the production domain |
| Preview Deployments | **left unchecked** — not yet observed |
| Ruleset and Advanced Security | **blocked** by plan |

Preview deployments stay unchecked deliberately. No task branch has been observed producing one, and this pull request is the first opportunity to find out.

## Changed Areas

- `docs/governance/github-configuration.md`
- `docs/governance/setup-checklist.md`

## Requirement Traceability

- PRD: Not applicable
- FAC: FAC-OWNER-002
- NFAC: NFAC-CICD-001, NFAC-SEC-001, NFAC-REC-001
- UX/UI: Not applicable
- Technical Design: §23.3

## Validation

- [x] Formatting check
- [ ] Lint
- [ ] Type check
- [ ] Content validation
- [ ] Unit/component tests
- [ ] Production build
- [ ] E2E tests, when relevant
- [ ] Accessibility checks, when relevant
- [ ] Link checks, when relevant
- [ ] Dependency/security audit, when relevant

### Commands and Results

```text
# Documentation only; no source touched. The full chain runs in CI on this
# pull request. Boxes left unchecked rather than claimed.

gh api repos/randifajar/developer-portfolio/rulesets
# 403 Upgrade to GitHub Pro or make this repository public

gh api repos/randifajar/developer-portfolio/branches/production/protection
# 403 Upgrade to GitHub Pro or make this repository public

gh api repos/randifajar/developer-portfolio --jq '{squash,merge_commit,rebase,auto_delete}'
# squash=true  merge_commit=false  rebase=false  auto_delete=true

prettier --check .
# All matched files use Prettier code style  (docs/ is excluded by design)
```

## Visual Evidence

Not applicable.

## Confidentiality Review

- [x] No credentials or secrets
- [x] No raw AI-session exports
- [x] No internal company URLs
- [x] No private repository content
- [x] No customer or student data
- [x] No unsafe screenshots or restricted evidence
- [x] Public claims and project status are truthful

## Deployment Impact

None. Documentation only.

## Rollback

Revert the squash commit. The documents return to asserting the ruleset is configurable today.

## Known Limitations

- The Advanced Security availability note says "likely blocked" rather than confirmed. The `security_and_analysis` API field returned empty, which is consistent with the features being unavailable but is not proof of each individual toggle. Confirm in Settings → Code security.
- This records the limitation; it does not resolve it. `production` remains technically unprotected until the repository becomes public or the plan changes.

## Merge Authorization

- [ ] Required checks passed
- [ ] Preview verified when applicable
- [ ] Review conversations resolved
- [ ] Randi explicitly approved merging this pull request
