### PR TITLE
feat: draft portfolio case study content and fix social image modelling

### DIFF
--- a/src/content/media.ts
+++ b/src/content/media.ts
@@ -31,16 +31,30 @@ export const mediaAssets = [
     confidentialityClass: "public",
     publicationStatus: "draft",
   }),
+  /*
+   * The social sharing card.
+   *
+   * Unlike the other assets here, this one is not a file waiting to be
+   * supplied. It is generated at request time by src/app/opengraph-image.tsx
+   * from the site configuration, so it cannot drift out of sync with the name
+   * and positioning shown on the site itself, and it needs no design work
+   * before launch.
+   *
+   * It is therefore Published now rather than Draft: the asset genuinely
+   * exists and is verified serving 200 image/png at 1200x630. The record
+   * previously pointed at a static PNG that was never created, which would
+   * have left the release gate asking for a file nobody should produce.
+   */
   defineMediaAsset({
     id: "media-social-card",
     type: "social-sharing-image",
-    filePath: "/images/social/portfolio-social-card.png",
+    filePath: "/opengraph-image",
     altText: "Randi Fajar Wicaksono — Backend-Focused Full-Stack Developer.",
     width: 1200,
     height: 630,
     ownerType: "metadata",
     ownerId: "profile-randi-fajar-wicaksono",
     confidentialityClass: "public",
-    publicationStatus: "draft",
+    publicationStatus: "published",
   }),
 ];

--- a/src/content/projects/personal-developer-portfolio.ts
+++ b/src/content/projects/personal-developer-portfolio.ts
@@ -13,9 +13,24 @@ import { defineProject } from "@/domain/content/define";
  * claiming a status the work has not reached, and "production" additionally
  * requires an explicit verified confirmation (TD 9.5).
  *
- * Sections marked DRAFT PLACEHOLDER need Randi's judgement or post-launch
- * facts. The rest describe decisions already made and visible in this
- * repository.
+ * Every section is now written from observable facts about this repository —
+ * decisions visible in the code, defects the checks actually caught, and
+ * behaviour verified against the live deployment. Nothing here is an invented
+ * achievement.
+ *
+ * REVIEW BEFORE PUBLISHING. Two things are Randi's call, not Claude's:
+ *
+ *   1. `role` says "Sole developer". The work was AI-accelerated under Randi's
+ *      direction, and `aiUsage` discloses that explicitly. The framing is
+ *      consistent with the site's positioning, but the wording is a claim
+ *      about Randi and only he can approve it.
+ *
+ *   2. `deliveryStatus` stays "in-development". The application is deployed
+ *      and verified running, but the portfolio has not launched — content is
+ *      still Draft and indexing is disabled. Moving to "production" would
+ *      additionally require a verified productionConfirmation (TD 9.5).
+ *
+ * publicationStatus stays "draft" until Randi has read every sentence.
  */
 export const personalDeveloperPortfolio = defineProject({
   id: "project-personal-developer-portfolio",
@@ -117,8 +132,16 @@ export const personalDeveloperPortfolio = defineProject({
   ],
 
   implementationSummary:
-    "DRAFT PLACEHOLDER: final implementation summary pending completion of the build. It will " +
-    "describe what was implemented and what was deliberately left out of Version 1.",
+    "Version 1 is a statically generated Next.js App Router site with no database, no runtime " +
+    "API, and no CMS. Content lives in typed TypeScript modules parsed by Zod at import, so a " +
+    "malformed record fails the build rather than reaching a page. Fifteen cross-record rules " +
+    "cover what no single schema can see — unique slugs, valid references, exactly one active " +
+    "resume, no published private content. A selector layer is the only path from content to " +
+    "pages, enforced by a lint rule rather than by convention.\n\n" +
+    "Everything else is deliberately absent: no authentication, admin dashboard, CMS, database, " +
+    "backend API, contact form, state-management library, UI component library, or analytics. " +
+    "Each was excluded by an explicit decision rather than left undone. Docker was scoped as a " +
+    "post-launch enhancement so it could not delay the launch.",
 
   testingAndVerification:
     "Domain logic is test-driven: schema rules, publication and confidentiality filtering, " +
@@ -128,8 +151,18 @@ export const personalDeveloperPortfolio = defineProject({
     "serious findings fail the run.",
 
   outcome:
-    "DRAFT PLACEHOLDER: outcome pending launch. It will describe the verified public result " +
-    "without invented metrics (FAC-PUBLISH-005).",
+    "The site is deployed and running on managed hosting, with the automated quality gate green " +
+    "on every merge: formatting, linting, strict type checking, content validation, unit and " +
+    "component tests, a production build, and end-to-end plus accessibility tests across three " +
+    "browser engines.\n\n" +
+    "The confidentiality behaviour is verified against the live deployment rather than assumed. " +
+    "An unknown project URL and an unpublished one return byte-identical responses, so the site " +
+    "cannot reveal that unpublished work exists. Unpublished projects are absent from the sitemap " +
+    "and carry no metadata, because their routes are never generated in the first place.\n\n" +
+    "Several defects were caught by the checks rather than by review: a colour pairing that " +
+    "failed the WCAG AA contrast threshold, two routes that shipped with no primary heading, and " +
+    "a build that passed locally but failed in CI because line endings differed between the two " +
+    "environments. Each was fixed at the cause and covered by a regression test.",
 
   aiUsage:
     "AI accelerated repository analysis, implementation planning, scoped code generation, and " +
@@ -139,8 +172,25 @@ export const personalDeveloperPortfolio = defineProject({
     "silently.",
 
   lessonsLearned:
-    "DRAFT PLACEHOLDER: lessons pending completion. Early observation: encoding a confidentiality " +
-    "rule as a validation failure is far more reliable than remembering to apply it.",
+    "**Encoding a rule beats remembering it.** The confidentiality requirements could have been a " +
+    "checklist. Making them validation failures meant that publishing restricted content, or " +
+    "labelling work as production without verified deployment, became impossible rather than " +
+    "merely discouraged.\n\n" +
+    "**Verifying each part is not the same as verifying the whole.** Two branches each passed " +
+    "their own checks and broke CI the moment they merged, because neither contained both the " +
+    "linter configuration and the file it needed to cover. The lesson was not to test more, but " +
+    "to test the combination that actually ships.\n\n" +
+    "**A local check that does not reproduce CI is worse than no local check.** The same commit " +
+    "passed locally and failed in CI because a Windows checkout and a Linux runner disagreed on " +
+    "line endings. Until that was normalised, every local 'verified' was quietly meaningless.\n\n" +
+    "**A quality threshold encodes a judgement, and mine was wrong.** The accessibility scan " +
+    "blocked on critical and serious findings only. Missing page headings are rated moderate, so " +
+    "two routes reached production with no primary heading at all. Tool severity describes how " +
+    "badly a rule breaks a page in general; it does not know which requirements a given project " +
+    "treats as launch-blocking.\n\n" +
+    "**Splitting the launch gate from the development gate was the decision that made the rest " +
+    "workable.** Development ran for the entire build against placeholder content, with a second " +
+    "validator that refused to let any of it reach production.",
 
   technologyIds: [
     "skill-typescript",

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -20,5 +20,9 @@ export const siteConfig = defineSiteConfig({
   email: "randifajar2307@gmail.com",
   linkedInUrl: "https://www.linkedin.com/in/randifajar",
   gitHubUrl: "https://github.com/randifajar",
-  defaultSocialImagePath: "/images/social/portfolio-social-card.png",
+  // The social card is generated at request time by src/app/opengraph-image.tsx
+  // rather than shipped as a static file, so it cannot drift out of sync with
+  // the name and positioning above. This is the public path Next.js serves it
+  // from — the earlier value pointed at a static PNG that was never created.
+  defaultSocialImagePath: "/opengraph-image",
 });


### PR DESCRIPTION
## Purpose

First substantive step of P30. Two things: a modelling defect that was inflating the release gate, and a draft of the one case study that can be written from observable facts.

## The social image was modelled wrongly

`media.ts` declared an asset at `/images/social/portfolio-social-card.png`, and `site.ts` pointed `defaultSocialImagePath` at the same path. **That file does not exist and should not** — the Open Graph image is generated at request time by `src/app/opengraph-image.tsx` from the site configuration, which is precisely why it cannot drift out of sync with the name and positioning shown on the site.

So the release gate was asking for a static PNG nobody should produce. Both records now point at `/opengraph-image`, the path Next.js actually serves — verified live returning `200 image/png` at 1200×630. The asset is marked **Published** because it genuinely exists rather than waiting on design work.

`defaultSocialImagePath` was also dead config: declared in the schema, set in `site.ts`, never read anywhere. It now names a real path.

**Launch blockers: 9 → 8.**

## The Personal Developer Portfolio case study is drafted

This case study is about *this repository*, so `implementationSummary`, `outcome`, and `lessonsLearned` are written from observable facts rather than recall. What was built is in the code; the deployment behaviour was verified against the live site; the defects described are ones the checks actually caught.

The lessons are the specific ones this build produced, not generic advice:

- Encoding a rule beats remembering it
- Verifying each branch is not the same as verifying the merged result
- A local check that does not reproduce CI is worse than no local check
- A quality threshold encodes a judgement that can itself be wrong — which is how a P0 heading requirement slipped past a scan tuned to critical and serious findings only

## Two things needing your decision, flagged in the file rather than decided here

1. **`role` says "Sole developer".** The work was AI-accelerated under your direction, and `aiUsage` discloses that explicitly. The framing is consistent with the site's positioning, but it is a claim about you and only you can approve the wording.
2. **`deliveryStatus` stays `in-development`.** The application is deployed and verified running, but the portfolio has not launched — content is Draft and indexing is disabled. Moving to `production` would additionally require a verified `productionConfirmation` (TD §9.5).

`publicationStatus` stays `draft` until you have read every sentence.

## Changed Areas

- `src/content/media.ts`
- `src/content/site.ts`
- `src/content/projects/personal-developer-portfolio.ts`

## Requirement Traceability

- PRD: §3.3, §5.3
- FAC: FAC-PROJECT-002, FAC-PROJECT-003, FAC-PUBLISH-005, FAC-OWNER-001
- NFAC: NFAC-CONTENT-001, NFAC-CONTENT-002, NFAC-SEO-004
- UX/UI: §9.5, §16.2, §18.3
- Technical Design: §9.5, §12

## Validation

- [x] Formatting check
- [ ] Lint
- [x] Type check
- [x] Content validation
- [x] Unit/component tests
- [x] Production build
- [ ] E2E tests, when relevant
- [ ] Accessibility checks, when relevant
- [ ] Link checks, when relevant
- [ ] Dependency/security audit, when relevant

### Commands and Results

```text
npx tsx scripts/validate-content.ts
# Content validation passed. 2 projects, 1 experience, 12 skills, 4 AI practices

SITE_URL=https://... npx tsx scripts/validate-release.ts
# 8 issues (was 9) — required-social-metadata cleared

npx vitest run          # 255 passed, 19 files
npx tsc --noEmit        # exit 0
npx next build          # exit 0
prettier --check .      # all files use Prettier code style

curl -sI https://developer-portfolio-delta-three.vercel.app/opengraph-image
# 200  image/png
```

Lint and E2E run in CI on this pull request; content-only changes do not affect them.

## Visual Evidence

No visible change yet. The case study remains Draft, so nothing new renders. The site still shows chrome plus the Contact section.

## Confidentiality Review

- [x] No credentials or secrets
- [x] No raw AI-session exports
- [x] No internal company URLs
- [x] No private repository content
- [x] No customer or student data
- [x] No unsafe screenshots or restricted evidence
- [x] Public claims and project status are truthful

Every claim in the case study is verifiable from this repository or the live deployment. No metrics are invented, and no achievement is asserted that the code does not demonstrate.

## Deployment Impact

None visible. The social card record becoming Published does not change rendering — the OG image was already being served by the file-based convention. It changes only what the release gate sees.

## Rollback

Revert the squash commit. The social blocker returns and the case study reverts to placeholders.

## Known Limitations

- Seven blockers remain, all requiring your input: profile headline and summary, work experience, skills classification, the Jury Process Management case study, an active resume PDF, and publishing two projects.
- `/opengraph-image` is a generated route rather than a static file. `localAssetPath` validation accepts it because it is a root-relative public path, but it is a route, not a file on disk — worth knowing if that validation is ever tightened.

## Merge Authorization

- [ ] Required checks passed
- [ ] Preview verified when applicable
- [ ] Review conversations resolved
- [ ] Randi explicitly approved merging this pull request
