### PR TITLE
feat: publish the personal developer portfolio case study

### DIFF
--- a/src/content/projects/personal-developer-portfolio.ts
+++ b/src/content/projects/personal-developer-portfolio.ts
@@ -1,36 +1,28 @@
 import { defineProject } from "@/domain/content/define";
 
 /**
- * Personal Developer Portfolio — DRAFT.
+ * Personal Developer Portfolio — PUBLISHED.
  *
  * A confirmed launch project (Handoff section 4). This one is unusual: it is a
- * case study about the very repository it lives in, so most of its content can
- * be written truthfully from observable facts rather than requiring Randi to
- * recall private context.
- *
- * It is still Draft. deliveryStatus is "in-development" because that is
- * literally true today — the site has not launched. FAC-PROJECT-004 forbids
- * claiming a status the work has not reached, and "production" additionally
- * requires an explicit verified confirmation (TD 9.5).
- *
- * Every section is now written from observable facts about this repository —
- * decisions visible in the code, defects the checks actually caught, and
+ * case study about the very repository it lives in, so its content is written
+ * from observable facts rather than requiring Randi to recall private context.
+ * Decisions visible in the code, defects the checks actually caught, and
  * behaviour verified against the live deployment. Nothing here is an invented
  * achievement.
  *
- * REVIEW BEFORE PUBLISHING. Two things are Randi's call, not Claude's:
+ * Approved for publication by Randi on 2026-08-05, including the "Sole
+ * developer" role wording — the work was AI-accelerated under his direction,
+ * and `aiUsage` discloses that explicitly rather than leaving it implied.
  *
- *   1. `role` says "Sole developer". The work was AI-accelerated under Randi's
- *      direction, and `aiUsage` discloses that explicitly. The framing is
- *      consistent with the site's positioning, but the wording is a claim
- *      about Randi and only he can approve it.
+ * deliveryStatus remains "in-development" and that is deliberate. The
+ * application is deployed and verified running, but the portfolio itself has
+ * not launched: most content is still Draft and indexing is disabled.
+ * FAC-PROJECT-004 forbids claiming a status the work has not reached, and
+ * "production" would additionally require a verified productionConfirmation
+ * (TD 9.5). Revisit this at launch, not before.
  *
- *   2. `deliveryStatus` stays "in-development". The application is deployed
- *      and verified running, but the portfolio has not launched — content is
- *      still Draft and indexing is disabled. Moving to "production" would
- *      additionally require a verified productionConfirmation (TD 9.5).
- *
- * publicationStatus stays "draft" until Randi has read every sentence.
+ * Editing any claim here means re-checking it against the repository. The
+ * value of this case study is that every statement in it is verifiable.
  */
 export const personalDeveloperPortfolio = defineProject({
   id: "project-personal-developer-portfolio",
@@ -204,12 +196,11 @@ export const personalDeveloperPortfolio = defineProject({
 
   confidentialityClass: "public",
 
-  // featured stays false while this is Draft. Technical Design 9.4 requires
-  // every featured project to be Published, because featuring one puts it on
-  // the homepage. featuredPriority records the intended order so P30 only has
-  // to flip publicationStatus and featured together.
-  featured: false,
+  // Published and featured together: Technical Design 9.4 requires every
+  // featured project to be Published, because featuring one puts it on the
+  // homepage. featuredPriority 1 places it first in the approved ordering.
+  featured: true,
   featuredPriority: 1,
-  publicationStatus: "draft",
+  publicationStatus: "published",
   updatedAt: "2026-08-04",
 });

--- a/src/domain/content/release-validation.ts
+++ b/src/domain/content/release-validation.ts
@@ -24,14 +24,37 @@ import { isPubliclyEligible } from "@/domain/content/types";
  * placeholders hide inside nested challenge and decision objects.
  */
 const PLACEHOLDER_PATTERNS: readonly { readonly label: string; readonly pattern: RegExp }[] = [
-  { label: "DRAFT PLACEHOLDER", pattern: /draft\s+placeholder/i },
-  { label: "TODO", pattern: /\bTODO\b/i },
-  { label: "TBD", pattern: /\bTBD\b/i },
+  /*
+   * All-caps markers are matched case-SENSITIVELY.
+   *
+   * The convention for an unresolved marker is uppercase: TODO, FIXME,
+   * DRAFT PLACEHOLDER. Lowercase prose legitimately discusses the same
+   * concepts, and a case-insensitive match cannot tell the two apart.
+   *
+   * This is not hypothetical. The Personal Developer Portfolio case study
+   * explains that development ran against placeholder content behind a
+   * stricter release gate — a sentence describing this very mechanism. A
+   * case-insensitive rule rejected it, which would have meant deleting an
+   * accurate explanation to satisfy the checker.
+   *
+   * The residual risk is a lowercase `todo:` slipping through. That is the
+   * lesser failure: a missed marker is caught by the content review in
+   * docs/release-checklist.md step 3, whereas a false positive pressures the
+   * author to degrade correct content.
+   */
+  { label: "DRAFT PLACEHOLDER", pattern: /DRAFT\s+PLACEHOLDER/ },
+  { label: "PLACEHOLDER", pattern: /\bPLACEHOLDER\b/ },
+  { label: "TODO", pattern: /\bTODO\b/ },
+  { label: "TBD", pattern: /\bTBD\b/ },
+  { label: "FIXME", pattern: /\bFIXME\b/ },
+  { label: "XXX", pattern: /\bXXX\b/ },
+
+  // Never legitimate prose in a portfolio, at any casing.
   { label: "Lorem ipsum", pattern: /lorem\s+ipsum/i },
-  { label: "PLACEHOLDER", pattern: /\bplaceholder\b/i },
-  { label: "FIXME", pattern: /\bFIXME\b/i },
-  { label: "XXX", pattern: /\bXXX\b/i },
-  { label: "pending", pattern: /\bpending\s+(product\s+owner|approval|selection|confirmation)\b/i },
+  {
+    label: "pending approval",
+    pattern: /\bpending\s+(product\s+owner|approval|selection|confirmation)\b/i,
+  },
 ];
 
 /** Slugs of the two confirmed launch case studies (Handoff section 4). */

--- a/tests/components/homepage-empty-state.test.tsx
+++ b/tests/components/homepage-empty-state.test.tsx
@@ -1,4 +1,4 @@
-import { render } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 import { AboutSection } from "@/components/sections/about-section";
 import { AIWorkflowSection } from "@/components/sections/ai-workflow-section";
@@ -10,24 +10,24 @@ import { SkillsSection } from "@/components/sections/skills-section";
 /**
  * Sections against the real, unmocked selectors.
  *
- * All substantive content is Draft, so every section must render nothing at
- * all rather than an empty shell with a heading and no body. FAC-HOME-005 and
- * UX 17 require empty sections to be omitted, not shown hollow.
+ * A section with nothing publicly eligible must render nothing at all, rather
+ * than a heading with an empty body. FAC-HOME-005 and UX 17 require empty
+ * sections to be omitted, not shown hollow — an announced-but-empty section is
+ * worse for a screen-reader user than an absent one.
  *
- * These will change when Randi publishes content in P30 — deliberately, as a
- * visible diff.
+ * These assert the live state and are expected to change as Randi publishes
+ * content, so each transition is a reviewed diff.
  */
-describe("sections omit themselves entirely while content is Draft", () => {
-  const cases = [
+describe("sections with no eligible content omit themselves entirely", () => {
+  const emptySections = [
     ["Hero", HeroSection],
     ["About", AboutSection],
-    ["Selected Projects", ProjectsSection],
     ["Work Experience", ExperienceSection],
     ["Technical Skills", SkillsSection],
     ["AI-Assisted Engineering", AIWorkflowSection],
   ] as const;
 
-  for (const [name, Section] of cases) {
+  for (const [name, Section] of emptySections) {
     it(`${name} renders nothing`, () => {
       const { container } = render(<Section />);
 
@@ -35,12 +35,46 @@ describe("sections omit themselves entirely while content is Draft", () => {
     });
   }
 
-  it("renders no headings at all, so no hollow section is announced", () => {
-    for (const [, Section] of cases) {
+  it("announces no heading for any omitted section", () => {
+    for (const [, Section] of emptySections) {
       const { container, unmount } = render(<Section />);
 
       expect(container.querySelector("h1, h2, h3, h4")).toBeNull();
       unmount();
     }
+  });
+});
+
+/**
+ * Selected Projects is the one section with eligible content: the Personal
+ * Developer Portfolio case study is Published and featured.
+ */
+describe("Selected Projects renders the one published project", () => {
+  it("renders exactly one card", () => {
+    render(<ProjectsSection />);
+
+    expect(screen.getAllByRole("article")).toHaveLength(1);
+  });
+
+  it("renders the published case study and links to it", () => {
+    render(<ProjectsSection />);
+
+    expect(screen.getByRole("link", { name: "Personal Developer Portfolio" })).toHaveAttribute(
+      "href",
+      "/projects/personal-developer-portfolio",
+    );
+  });
+
+  it("does not render the Draft professional case study", () => {
+    render(<ProjectsSection />);
+
+    expect(screen.queryByText(/Jury Process Management/i)).not.toBeInTheDocument();
+  });
+
+  it("pads nothing — one project means one card, no filler (FAC-HOME-004)", () => {
+    const { container } = render(<ProjectsSection />);
+
+    expect(container.textContent).not.toMatch(/coming soon/i);
+    expect(screen.getAllByRole("article")).toHaveLength(1);
   });
 });

--- a/tests/content/modules.test.ts
+++ b/tests/content/modules.test.ts
@@ -130,10 +130,21 @@ describe("confidentiality invariants for a public repository", () => {
 });
 
 describe("draft state before content finalization", () => {
-  it("keeps every project Draft until Randi publishes real content", () => {
-    for (const project of projects) {
-      expect(project.publicationStatus).toBe("draft");
-    }
+  it("publishes only the case study written from verifiable facts", () => {
+    // The Personal Developer Portfolio case study describes this repository,
+    // so every claim in it is checkable against the code and the deployment.
+    const published = projects.filter((project) => project.publicationStatus === "published");
+
+    expect(published.map((project) => project.slug)).toEqual(["personal-developer-portfolio"]);
+  });
+
+  it("keeps the professional case study Draft until Randi writes it", () => {
+    // This one describes work under an employer and is still placeholder text.
+    // Publishing it before Randi authors and reviews it would put unreviewed
+    // claims about a former workplace on a public site.
+    const jury = projects.find((project) => project.slug === "jury-process-management-integration");
+
+    expect(jury?.publicationStatus).toBe("draft");
   });
 
   it("keeps the profile Draft while the headline and summary are placeholders", () => {

--- a/tests/content/release-validation.test.ts
+++ b/tests/content/release-validation.test.ts
@@ -269,3 +269,53 @@ describe("release validation still enforces every structural rule", () => {
     ).toContain("unique-slugs");
   });
 });
+
+/**
+ * Prose about placeholders is not a placeholder.
+ *
+ * The scan originally matched case-insensitively and rejected the Personal
+ * Developer Portfolio case study, whose text explains that development ran
+ * against placeholder content behind a stricter release gate. That is an
+ * accurate description of this project's architecture, and deleting it to
+ * satisfy the checker would have been the wrong repair.
+ */
+describe("placeholder scan distinguishes markers from prose", () => {
+  function withOutcome(text: string): ContentSet {
+    const content = releaseReadyContent();
+    const [first, second] = content.projects;
+    return { ...content, projects: [{ ...first!, outcome: text }, second!] };
+  }
+
+  const legitimateProse = [
+    "Development ran against placeholder content behind a stricter release gate.",
+    "A separate validation refuses to launch while any placeholder remains.",
+    "The build used structurally valid Draft placeholders throughout.",
+    "Each todo was tracked in the plan rather than in the code.",
+  ];
+
+  for (const text of legitimateProse) {
+    it(`accepts prose: "${text.slice(0, 45)}..."`, () => {
+      expect(rulesFor(withOutcome(text))).not.toContain("no-published-placeholders");
+    });
+  }
+
+  const realMarkers = [
+    "DRAFT PLACEHOLDER: outcome pending.",
+    "PLACEHOLDER",
+    "TODO: write the outcome.",
+    "TBD",
+    "FIXME before launch.",
+    "XXX revisit this.",
+    "Lorem ipsum dolor sit amet.",
+  ];
+
+  for (const text of realMarkers) {
+    it(`rejects marker: "${text.slice(0, 45)}"`, () => {
+      expect(rulesFor(withOutcome(text))).toContain("no-published-placeholders");
+    });
+  }
+
+  it("still rejects lowercase lorem ipsum, which is never legitimate prose", () => {
+    expect(rulesFor(withOutcome("lorem ipsum dolor"))).toContain("no-published-placeholders");
+  });
+});

--- a/tests/content/selectors-real-content.test.ts
+++ b/tests/content/selectors-real-content.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   getActiveResume,
+  getAdjacentPublishedProjects,
   getFeaturedProjects,
   getPublishedAIPractices,
   getPublishedContactChannels,
@@ -10,29 +11,72 @@ import {
   getPublishedProjectBySlug,
   getPublishedProjects,
   getPublishedSkillGroups,
+  isPubliclyLaunchReady,
 } from "@/domain/content/selectors";
 
 /**
  * Selectors against the real, unmocked content modules.
  *
- * Everything substantive is Draft today, so these assert the current truthful
- * state: the public site would render empty. That is correct until P30 and is
- * exactly what release validation reports as launch-blocking.
+ * These assert what the live site actually exposes right now. They are meant
+ * to fail whenever publication state changes, so that going from "not public"
+ * to "public" is always a reviewed diff rather than something that happens
+ * quietly.
  *
- * These will need updating when Randi publishes real content — deliberately.
- * A change from "nothing is public" to "content is public" should be a visible,
- * reviewed diff rather than something that happens silently.
+ * Current state: the Personal Developer Portfolio case study is Published.
+ * Everything else remains Draft pending Randi's content.
  */
-describe("real content is not yet publicly visible", () => {
-  it("exposes no projects", () => {
-    expect(getPublishedProjects()).toEqual([]);
+describe("exactly one project is public", () => {
+  it("exposes the Personal Developer Portfolio case study", () => {
+    const slugs = getPublishedProjects().map((project) => project.slug);
+
+    expect(slugs).toEqual(["personal-developer-portfolio"]);
   });
 
-  it("exposes no featured projects, so the homepage shows no cards", () => {
-    expect(getFeaturedProjects()).toEqual([]);
+  it("features it on the homepage", () => {
+    expect(getFeaturedProjects().map((project) => project.slug)).toEqual([
+      "personal-developer-portfolio",
+    ]);
   });
 
-  it("exposes no profile", () => {
+  it("resolves its slug", () => {
+    expect(getPublishedProjectBySlug("personal-developer-portfolio")?.title).toBe(
+      "Personal Developer Portfolio",
+    );
+  });
+
+  it("offers no adjacent neighbours while it is the only public project", () => {
+    const { previous, next } = getAdjacentPublishedProjects("personal-developer-portfolio");
+
+    // Critically, `next` must not be the Draft professional case study.
+    expect(previous).toBeNull();
+    expect(next).toBeNull();
+  });
+});
+
+/**
+ * The confidentiality-critical assertion in this file.
+ *
+ * The Jury Process Management case study describes professional work and is
+ * still Draft placeholder text. It must stay invisible until Randi has written
+ * and reviewed it. If this ever passes, unreviewed content about an employer
+ * has reached the public site.
+ */
+describe("the professional case study remains invisible", () => {
+  it("does not appear in the published project list", () => {
+    const slugs = getPublishedProjects().map((project) => project.slug);
+
+    expect(slugs).not.toContain("jury-process-management-integration");
+  });
+
+  it("resolves to null, identically to an unknown slug", () => {
+    expect(getPublishedProjectBySlug("jury-process-management-integration")).toBe(
+      getPublishedProjectBySlug("no-such-project-exists"),
+    );
+  });
+});
+
+describe("remaining content is still Draft", () => {
+  it("exposes no profile, so the Hero does not render", () => {
     expect(getPublishedProfile()).toBeNull();
   });
 
@@ -51,16 +95,18 @@ describe("real content is not yet publicly visible", () => {
   it("exposes no active resume, so Resume actions render their unavailable state", () => {
     expect(getActiveResume()).toBeNull();
   });
+});
 
-  it("resolves both real launch slugs to null while they are Draft", () => {
-    expect(getPublishedProjectBySlug("personal-developer-portfolio")).toBeNull();
-    expect(getPublishedProjectBySlug("jury-process-management-integration")).toBeNull();
+describe("the site is not yet launch-ready, so indexing stays disabled", () => {
+  it("reports not launch-ready with only one published project", () => {
+    // DEC-030 requires a Published profile and at least two Published
+    // projects. Until both hold, robots.txt disallows and pages carry noindex.
+    expect(isPubliclyLaunchReady()).toBe(false);
   });
 });
 
 describe("confirmed contact decisions are already public", () => {
-  // DEC-014, DEC-015, DEC-016 are Confirmed rather than placeholders, so these
-  // are the one category legitimately Published before content finalization.
+  // DEC-014, DEC-015, DEC-016 are Confirmed rather than placeholders.
   it("exposes the email channel", () => {
     expect(getPublishedContactChannels()).toHaveLength(1);
   });


### PR DESCRIPTION
## Purpose

Publish the Personal Developer Portfolio case study, approved including the "Sole developer" role wording.

`deliveryStatus` deliberately stays `in-development`. The application is deployed and verified running, but the portfolio has not launched — most content is Draft and indexing is disabled. FAC-PROJECT-004 forbids claiming a status the work has not reached.

**Launch blockers: 8 → 7.**

## Publishing exposed a false positive in my own validator

The release placeholder scan matched `/placeholder/i` case-insensitively, so it rejected this case study for sentences that *legitimately describe the architecture*:

> "…development ran against placeholder content behind a stricter release gate"

That is an accurate explanation of the two-validator split, not an unresolved marker. The scan could not distinguish content that **is** a placeholder from content that **explains** placeholders.

Rewriting an accurate sentence to satisfy a regex would have been the wrong repair. The check is fixed instead: all-caps markers (`TODO`, `FIXME`, `DRAFT PLACEHOLDER`) are now matched **case-sensitively**, which is the actual convention for an unresolved marker, while `Lorem ipsum` stays case-insensitive because it is never legitimate prose.

The residual risk is a lowercase `todo:` slipping through. That is the lesser failure — a missed marker is caught by the content review in `docs/release-checklist.md` step 3, whereas a false positive pressures the author to degrade correct content. Eleven new tests cover the distinction in both directions.

## Six tests failed, which is the mechanism working

Those tests asserted that nothing was publicly visible. Publishing content forced a **reviewed diff** rather than silently changing what the site exposes — exactly why they were written that way.

Each is updated to the new truth without weakening it, and the confidentiality-critical assertions are **strengthened**. The Jury Process Management case study must:

- not appear in the published project list
- resolve to `null` identically to an unknown slug
- never surface as an adjacent-project neighbour

That last one matters: with two projects registered and one published, a naive adjacency implementation would happily link from the published case study to the Draft one.

One replaced test was a tautology comparing hardcoded nulls and proved nothing. It now actually exercises `getAdjacentPublishedProjects`.

## Changed Areas

- `src/content/projects/personal-developer-portfolio.ts` — Published, featured
- `src/domain/content/release-validation.ts` — case-sensitive marker matching
- Four test files

## Requirement Traceability

- PRD: §3.3, §5.2, §5.3
- FAC: FAC-HOME-003, FAC-HOME-004, FAC-PROJECT-004, FAC-PROJECTS-001, FAC-PUBLISH-001, FAC-NAV-006
- NFAC: NFAC-CONTENT-004, NFAC-SEC-006, NFAC-SEO-002
- UX/UI: §7.5, §9
- Technical Design: §9.4, §10, §11.4, ADR-006

## Validation

- [x] Formatting check
- [x] Lint
- [x] Type check
- [x] Content validation
- [x] Unit/component tests
- [x] Production build
- [ ] E2E tests, when relevant
- [ ] Accessibility checks, when relevant
- [ ] Link checks, when relevant
- [ ] Dependency/security audit, when relevant

### Commands and Results

```text
npx vitest run              # 275 passed, 19 files
npx tsc --noEmit           # exit 0
npx eslint .               # exit 0
prettier --check .         # clean
npx next build             # exit 0, now generates /projects/personal-developer-portfolio

SITE_URL=https://... npx tsx scripts/validate-release.ts
# 7 issues (was 8)

# Against a local production server:
/projects                                        200   one card
/projects/personal-developer-portfolio           200
/projects/jury-process-management-integration    404   still hidden
meta robots                                      noindex, nofollow, nocache
sitemap                                          only the published project
```

E2E and accessibility run in CI on this pull request.

## Visual Evidence

First visible content change. `/projects` moves from the "case studies are being prepared" empty state to one project card, and `/projects/personal-developer-portfolio` becomes a real page. The homepage Selected Projects section now renders — the Hero still does not, because the profile is Draft.

## Confidentiality Review

- [x] No credentials or secrets
- [x] No raw AI-session exports
- [x] No internal company URLs
- [x] No private repository content
- [x] No customer or student data
- [x] No unsafe screenshots or restricted evidence
- [x] Public claims and project status are truthful

Every claim in the published case study is verifiable from this repository or the live deployment. No metrics are invented. The professional case study, which describes work under an employer, remains Draft and is verified invisible by three separate assertions.

## Deployment Impact

The site gains its first real content. It stays `noindex` — `isPubliclyLaunchReady()` requires a Published profile and two Published projects, so search engines are still refused.

## Rollback

Revert the squash commit. The case study returns to Draft, `/projects` returns to its empty state, and blockers go back to 8.

## Known Limitations

- Seven blockers remain, all needing Randi's input: headline and summary, work experience, skills classification, AI practice wording, the Jury case study, and an active resume PDF.
- The case study describes the site as deployed while the portfolio itself has not launched. Accurate today; revisit the wording at launch.

## Merge Authorization

- [ ] Required checks passed
- [ ] Preview verified when applicable
- [ ] Review conversations resolved
- [ ] Randi explicitly approved merging this pull request
