### PR TITLE
fix: drive end-to-end privacy assertions from the project registry

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { projects } from "@/content/projects";
 
 test.describe("public routes (NFAC-REL-001)", () => {
   const publicRoutes = ["/", "/projects"];
@@ -38,40 +39,65 @@ test.describe("invalid routes (FAC-NAV-005)", () => {
 /**
  * The privacy guarantee, verified end to end (DEC-047, FAC-NAV-006).
  *
- * An unknown slug and a Draft slug must be indistinguishable to a visitor.
- * Asserting equal bodies rather than merely equal status codes is what makes
- * this meaningful — two 404s with different copy would still leak.
+ * Every registered project is either publicly reachable or byte-identical to a
+ * slug that was never registered at all. The absence of any third state is the
+ * guarantee — two 404s with different copy would still leak.
+ *
+ * This block used to hardcode personal-developer-portfolio as "the Draft slug".
+ * Publishing that project pointed the whole block at a public page. It failed
+ * loudly rather than passing silently, but a single content change should not
+ * be able to retire the guarantee, so the slugs now come from the registry.
+ *
+ * The raw registry is deliberately the source rather than a selector. Asking
+ * the selector which projects are hidden and then asserting those are hidden
+ * would be circular: a selector that wrongly exposed a private project would
+ * also report it as public, and this test would still pass. The registry states
+ * what exists; the running server is checked independently.
  */
-test.describe("unpublished projects are indistinguishable from unknown ones", () => {
-  const unknownSlug = "/projects/definitely-not-a-real-project";
-  const draftSlug = "/projects/personal-developer-portfolio";
+test.describe("registered projects are either public or indistinguishable from unknown", () => {
+  const unknownRoute = "/projects/definitely-not-a-real-project";
+  const registeredRoutes = projects.map((project) => `/projects/${project.slug}`);
 
-  test("both return 404", async ({ request }) => {
-    expect((await request.get(unknownSlug)).status()).toBe(404);
-    expect((await request.get(draftSlug)).status()).toBe(404);
+  test("an unregistered slug returns 404", async ({ request }) => {
+    expect((await request.get(unknownRoute)).status()).toBe(404);
   });
 
-  test("both return identical response bodies", async ({ request }) => {
-    const unknownBody = await (await request.get(unknownSlug)).text();
-    const draftBody = await (await request.get(draftSlug)).text();
+  test("a hidden project returns a body identical to an unregistered one", async ({ request }) => {
+    const unknownBody = await (await request.get(unknownRoute)).text();
 
-    expect(draftBody).toBe(unknownBody);
-  });
+    for (const route of registeredRoutes) {
+      const response = await request.get(route);
 
-  test("the Not Found page never hints that hidden content exists", async ({ page }) => {
-    await page.goto(draftSlug);
-    const body = (await page.textContent("body")) ?? "";
+      // 200 means Published and publicly eligible, which is a valid state.
+      // Anything else must be indistinguishable from a slug that never existed.
+      if (response.status() === 200) continue;
 
-    for (const phrase of [/not yet published/i, /draft/i, /private/i, /restricted/i]) {
-      expect(body).not.toMatch(phrase);
+      expect(response.status(), route).toBe(404);
+      expect(await response.text(), route).toBe(unknownBody);
     }
   });
 
-  test("no unpublished slug appears in the sitemap (NFAC-SEO-002)", async ({ request }) => {
+  test("the Not Found page never hints that hidden content exists", async ({ page, request }) => {
+    for (const route of registeredRoutes) {
+      if ((await request.get(route)).status() === 200) continue;
+
+      await page.goto(route);
+      const body = (await page.textContent("body")) ?? "";
+
+      for (const phrase of [/not yet published/i, /draft/i, /private/i, /restricted/i]) {
+        expect(body, route).not.toMatch(phrase);
+      }
+    }
+  });
+
+  test("the sitemap lists exactly the reachable projects (NFAC-SEO-002)", async ({ request }) => {
     const sitemap = await (await request.get("/sitemap.xml")).text();
 
-    expect(sitemap).not.toContain("personal-developer-portfolio");
-    expect(sitemap).not.toContain("jury-process-management-integration");
+    for (const route of registeredRoutes) {
+      const isReachable = (await request.get(route)).status() === 200;
+
+      expect(sitemap.includes(route), route).toBe(isReachable);
+    }
   });
 });
 

--- a/e2e/projects.spec.ts
+++ b/e2e/projects.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/test";
+import { projects } from "@/content/projects";
 
 test.describe("Projects Index (FAC-PROJECTS-001, 004)", () => {
   test.beforeEach(async ({ page }) => {
@@ -16,20 +17,37 @@ test.describe("Projects Index (FAC-PROJECTS-001, 004)", () => {
   });
 
   /**
-   * No project is Published today, so the truthful empty state is what should
-   * appear. This is a valid page state but not a launch-ready product state —
-   * release validation is what refuses the launch.
+   * Driven by what the server actually serves rather than by a hardcoded count,
+   * so publishing the second case study does not require editing these.
+   *
+   * The empty state these replaced is no longer reachable now that a project is
+   * Published. It remains covered by release validation, which is what refuses
+   * a launch with too few case studies (FAC-PROJECTS-004).
    */
-  test("shows the truthful empty state while nothing is Published", async ({ page }) => {
-    await expect(page.getByText(/case studies are being prepared/i)).toBeVisible();
+  test("renders a card for every publicly reachable project", async ({ page, request }) => {
+    const reachable: string[] = [];
+
+    for (const project of projects) {
+      if ((await request.get(`/projects/${project.slug}`)).status() === 200) {
+        reachable.push(project.title);
+      }
+    }
+
+    await expect(page.getByRole("article")).toHaveCount(reachable.length);
+
+    for (const title of reachable) {
+      await expect(page.getByRole("link", { name: title })).toBeVisible();
+    }
   });
 
-  test("offers recovery actions from the empty state", async ({ page }) => {
-    await expect(page.getByRole("link", { name: /return home/i })).toBeVisible();
-  });
+  test("names no hidden project anywhere on the page", async ({ page, request }) => {
+    const body = (await page.textContent("body")) ?? "";
 
-  test("shows no Draft project card", async ({ page }) => {
-    await expect(page.getByRole("article")).toHaveCount(0);
+    for (const project of projects) {
+      if ((await request.get(`/projects/${project.slug}`)).status() === 200) continue;
+
+      expect(body, project.slug).not.toContain(project.title);
+    }
   });
 
   test("invents no placeholder or Coming Soon card (FAC-HOME-004)", async ({ page }) => {


### PR DESCRIPTION
## Purpose

Restore CI to green on `production` and repair the end-to-end privacy guarantee that publishing the case study left pointed at the wrong target.

CI failed on `production` at `38c8cf6` (PR #14): `quality` passed, `e2e` failed with 21 failures — 7 tests across 3 engines.

## What went wrong

Two separate problems, and the second is the reason this is not just a test-maintenance chore.

**Ordinary staleness.** `e2e/projects.spec.ts` asserted the truthful empty state and a zero card count. Both were correct only while nothing was Published.

**A guarantee left unattended.** `e2e/navigation.spec.ts:47` hardcoded `personal-developer-portfolio` as its representative unpublished slug — reasonable when both projects were Draft. Publishing it pointed the entire privacy block at a public page. It failed loudly rather than passing silently, which is the good outcome, but a single content change should not be able to retire the guarantee.

**My miss:** I ran the 275 unit tests before pushing #14 and did not run the e2e suite. The unit tests could not have caught this — the specs that broke only exist at the E2E layer. This is a narrower repeat of the lesson already written into the case study: verifying part of the gate is not verifying the gate.

## Implementation summary

Both files derive their slugs from the project registry and ask the running server for reachability, so assertions follow content state rather than being invalidated by it.

The asserted property: **every registered project is either publicly reachable or byte-identical to a slug that was never registered.** The absence of a third state is the guarantee (DEC-047, FAC-NAV-006).

The raw registry is deliberately the source rather than a selector. Asking the selector which projects are hidden and then asserting those are hidden would be circular — a selector that wrongly exposed a private project would also report it as public, and the test would still pass. The registry states what exists; the server is checked independently.

Net effect: publishing the second case study will require no edit to these specs.

## Changed areas

| File | Change |
|---|---|
| `e2e/navigation.spec.ts` | Privacy block rewritten registry-driven; sitemap test now asserts exact correspondence between reachability and listing, in both directions |
| `e2e/projects.spec.ts` | Empty-state and zero-card assertions replaced with card-count-matches-reachable and no-hidden-title-leaks |

## Tests and commands run

- `npx playwright test` — **125 passed**, 1 skipped, Chromium + Firefox + WebKit. The skip is the documented WebKit skip-link platform default.
- `npm run check` — exit 0 (format, lint, typecheck, validate:content, 275 unit tests, build).
- Build emits exactly one project route: `/projects/personal-developer-portfolio`.

**Mutation-verified rather than assumed.** A loop that iterates nothing passes silently, so both branches were proven capable of failing:

- Inverting the sitemap assertion → fails naming `/projects/personal-developer-portfolio` (reachable branch runs).
- Inverting the identical-body assertion → fails naming `/projects/jury-process-management-integration` (hidden branch runs, and genuinely compares bodies).

## Known limitations

The Projects Index empty state (`src/app/projects/page.tsx`) is no longer reachable now that a project is Published, so it lost its only automated coverage. It is defensive code, and release validation still refuses a launch with too few case studies (FAC-PROJECTS-004). Restoring coverage would mean extracting it into its own component — out of scope for a CI fix.

## Confidentiality review

Pass. Test-only change. No content, credentials, internal URLs, or identifiers. The specs reference two slugs already public in the repository.

## Deployment impact

None. No application code changed; no route, page, or content is affected.

## Rollback notes

`git revert` of the squash commit restores the previous specs and re-breaks CI. Reverting PR #14 instead would unpublish the case study.

## FAC/NFAC references

FAC-NAV-006, FAC-PROJECTS-001, FAC-PROJECTS-004, DEC-047, NFAC-SEO-002, NFAC-SEC-006, NFAC-TEST-001
