### PR TITLE
fix: add a generated tab icon so no page 404s on favicon.ico

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -101,6 +101,74 @@ test.describe("registered projects are either public or indistinguishable from u
   });
 });
 
+/**
+ * No public page may log a browser error or 404 a subresource.
+ *
+ * Prompted by the P29 release audit, which found /favicon.ico returning 404 on
+ * every route — one missing asset that logged a console error on every page and
+ * cost four points of Lighthouse Best Practices.
+ *
+ * Read the division of labour here carefully, because it is not what it looks
+ * like. The console assertions do NOT catch that defect, and this was checked
+ * rather than assumed: removing icon.tsx and re-running leaves all three of
+ * them green. Headless Chromium under automation never requests /favicon.ico at
+ * all, so there is no error for them to observe. A real browser does, which is
+ * why Lighthouse saw it and Playwright cannot.
+ *
+ * The tab icon test below is therefore the actual regression test for the
+ * favicon, and it does fail when icon.tsx is removed.
+ *
+ * The console assertions still earn their place, but for a different class:
+ * uncaught exceptions, and subresources the page genuinely requests and gets a
+ * 4xx or 5xx for. A 404 is a successful HTTP exchange, so it fires neither
+ * requestfailed nor a console error under automation — hence the explicit
+ * response listener.
+ */
+test.describe("public pages log no browser errors", () => {
+  const routes = ["/", "/projects", "/projects/personal-developer-portfolio"];
+
+  for (const route of routes) {
+    test(`${route} logs nothing to the console`, async ({ page }) => {
+      const errors: string[] = [];
+
+      page.on("console", (message) => {
+        if (message.type() === "error") errors.push(message.text());
+      });
+      page.on("pageerror", (error) => errors.push(error.message));
+      page.on("requestfailed", (request) => {
+        errors.push(`request failed: ${request.url()}`);
+      });
+      // A 404 is a successful HTTP exchange, so it fires neither requestfailed
+      // nor, under automation, a console error. Without this listener a page
+      // could quietly 404 on a subresource and still pass.
+      page.on("response", (response) => {
+        if (response.status() >= 400) {
+          errors.push(`HTTP ${response.status()} ${response.url()}`);
+        }
+      });
+
+      await page.goto(route, { waitUntil: "networkidle" });
+
+      expect(errors, `${route} logged: ${errors.join(" | ")}`).toEqual([]);
+    });
+  }
+
+  test("the tab icon is declared and served", async ({ page, request }) => {
+    await page.goto("/");
+
+    // A declared icon is what stops the browser requesting /favicon.ico, so
+    // asserting the link element is asserting the actual fix.
+    const href = await page.locator('link[rel="icon"]').first().getAttribute("href");
+
+    expect(href).toBeTruthy();
+
+    const response = await request.get(href ?? "");
+
+    expect(response.status()).toBe(200);
+    expect(response.headers()["content-type"]).toContain("image/");
+  });
+});
+
 test.describe("security headers (NFAC-SEC-005)", () => {
   test("are present on a page response", async ({ request }) => {
     const headers = (await request.get("/")).headers();

--- a/src/app/icon.tsx
+++ b/src/app/icon.tsx
@@ -1,0 +1,57 @@
+import { ImageResponse } from "next/og";
+import { getSiteConfig } from "@/domain/content/selectors";
+
+export const size = { width: 32, height: 32 };
+export const contentType = "image/png";
+
+/**
+ * The browser tab icon.
+ *
+ * Added because the P29 release audit found /favicon.ico returning 404 on every
+ * page. That is small but not cosmetic: it logged a browser console error on
+ * every route, which Lighthouse counts against Best Practices, and it left the
+ * tab showing a blank default icon on a site whose whole purpose is being
+ * opened by a recruiter.
+ *
+ * Generated rather than shipped as a binary, matching opengraph-image.tsx. The
+ * initials come from the site configuration, so the icon cannot drift out of
+ * sync with the name on the site, and no design asset has to be produced before
+ * launch.
+ *
+ * Colours are the literal token values rather than CSS variables — this runs in
+ * the image renderer, which has no access to the stylesheet.
+ */
+export default function Icon() {
+  const siteConfig = getSiteConfig();
+
+  // "Randi Fajar Wicaksono" becomes "RF". Two letters is the most that stays
+  // legible at 32 pixels; three is a smudge.
+  const initials = siteConfig.ownerName
+    .split(/\s+/)
+    .filter((part) => part.length > 0)
+    .slice(0, 2)
+    .map((part) => part[0]?.toUpperCase() ?? "")
+    .join("");
+
+  return new ImageResponse(
+    <div
+      style={{
+        width: "100%",
+        height: "100%",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        backgroundColor: "#2563EB",
+        color: "#FFFFFF",
+        fontSize: 17,
+        fontWeight: 700,
+        letterSpacing: -0.5,
+        fontFamily: "sans-serif",
+        borderRadius: 6,
+      }}
+    >
+      {initials}
+    </div>,
+    size,
+  );
+}


### PR DESCRIPTION
## Purpose

The P29 Lighthouse audit found `/favicon.ico` returning **404 on every route**.

Small, but not cosmetic: it logged a browser console error on all three page types, cost four points of Best Practices, and left the tab showing a blank default icon on a site whose entire purpose is being opened by a recruiter.

## Implementation summary

`src/app/icon.tsx` generates the icon, matching the existing `opengraph-image.tsx` pattern. Initials are derived from the site configuration, so the icon cannot drift out of sync with the name on the site, and no design asset has to be produced before launch.

Declaring `<link rel="icon">` is what stops the browser requesting `/favicon.ico`. That path still 404s and no longer matters — nothing asks for it.

**Measured, not assumed** — local production build, Lighthouse before and after:

| | Before | After |
|---|---|---|
| Best Practices | 96 | **100** |
| `errors-in-console` | 1 item | **0 items** |

## The regression tests carry a caveat — please read it

Removing `icon.tsx` and re-running leaves **all three console-error assertions green**. Headless Chromium under automation never requests `/favicon.ico`, so there is no error for them to observe. A real browser does, which is why Lighthouse caught this and Playwright could not.

**The tab icon test is the actual regression test here**, and it does fail when `icon.tsx` is removed. I verified this in both directions rather than inferring it, and the comment in the spec states it plainly so nobody later mistakes the console assertions for favicon coverage.

The console assertions still earn their place, for a different class: uncaught exceptions, and subresources the page genuinely requests and receives a 4xx/5xx for. A 404 is a successful HTTP exchange — it fires neither `requestfailed` nor a console error under automation — so an explicit `response` listener covers that gap.

## Changed areas

| File | Change |
|---|---|
| `src/app/icon.tsx` | New. Generated 32×32 monogram from `siteConfig.ownerName` |
| `e2e/navigation.spec.ts` | 4 tests: no console errors or 4xx/5xx subresources on three routes, plus the icon-declared-and-served assertion |

## Tests and commands run

- `npm run check` — exit 0, 295 tests
- `npx playwright test` — **137 passed** (was 125; +4 tests × 3 engines), 1 skipped, Chromium + Firefox + WebKit
- Lighthouse on a local production build — Best Practices 100, Accessibility 100
- Mutation check both directions: icon present → 4 pass; icon removed → tab icon test fails, console tests do not

## Known limitations

The console assertions do not cover browser-initiated requests that only real browsers make. Documented in the spec rather than papered over. Lighthouse remains the check that sees those, and it is a release-audit step.

## Deployment impact

One new static route, `/icon`. No content or existing route changes.

## Rollback notes

`git revert` removes the icon and restores the `/favicon.ico` 404. The tab icon e2e test would then fail, so a revert cannot land quietly.

## Confidentiality review

Pass. The icon renders initials already published site-wide.

## FAC/NFAC references

NFAC-PERF-002, NFAC-REL-001, NFAC-TEST-001
