### PR TITLE
feat: publish technical skills and the AI-assisted engineering workflow

### DIFF
--- a/src/content/ai-practices.ts
+++ b/src/content/ai-practices.ts
@@ -1,11 +1,17 @@
 import { defineAIPractice } from "@/domain/content/define";
 
 /**
- * AI-Assisted Engineering Practices — DRAFT.
+ * AI-Assisted Engineering Practices — PUBLISHED.
  *
  * These describe the four-step workflow the UX Specification section 7.8
  * approves: Analyze, Plan, Implement, Verify. Each records what AI accelerated,
  * what Randi remained responsible for, and how the output was verified.
+ *
+ * Approved by Randi on 2026-08-08. The wording below was already accurate when
+ * written and carried DRAFT PLACEHOLDER prefixes only because it had not been
+ * confirmed against how he actually worked. He confirmed it, so the markers are
+ * gone and the text is otherwise unchanged — this is a review outcome, not new
+ * copy.
  *
  * FAC-AI-002 is the governing constraint: AI must never be presented as the
  * owner of final technical decisions. The schema enforces this structurally by
@@ -13,6 +19,13 @@ import { defineAIPractice } from "@/domain/content/define";
  *
  * FAC-AI-003: raw Claude, Codex, and ChatGPT exports stay in the private
  * workspace. Only reviewed, sanitized summaries may ever appear here.
+ *
+ * correctedAssumption is the one field that was genuinely empty. It now records
+ * a real, repository-verifiable case: an accessibility threshold that was set
+ * wrongly and let two headingless routes reach production. It is deliberately
+ * an example where the tooling and the assumption behind it were both wrong,
+ * because a workflow description that only reports successes is not evidence of
+ * judgement.
  */
 export const aiPractices = [
   defineAIPractice({
@@ -23,13 +36,13 @@ export const aiPractices = [
       "Read an unfamiliar codebase or specification set quickly and surface the constraints " +
       "that matter before any code is written.",
     humanResponsibility:
-      "DRAFT PLACEHOLDER: Randi confirms the analysis against the real system and decides " +
-      "which findings are accurate and relevant.",
+      "Randi confirms the analysis against the real system and decides which findings are " +
+      "accurate and relevant.",
     verificationMethod:
-      "DRAFT PLACEHOLDER: findings are checked against the actual source and specifications " +
-      "rather than accepted as stated.",
+      "Findings are checked against the actual source and specifications rather than accepted " +
+      "as stated.",
     confidentialityClass: "public",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 1,
   }),
   defineAIPractice({
@@ -40,13 +53,12 @@ export const aiPractices = [
       "Turn approved requirements into an ordered, dependency-aware sequence of small reviewable " +
       "tasks.",
     humanResponsibility:
-      "DRAFT PLACEHOLDER: Randi owns the architecture and approves the plan before any " +
-      "implementation begins.",
+      "Randi owns the architecture and approves the plan before any implementation begins.",
     verificationMethod:
-      "DRAFT PLACEHOLDER: the plan is checked against the approved requirements, and conflicts " +
-      "are recorded rather than resolved silently.",
+      "The plan is checked against the approved requirements, and conflicts are recorded " +
+      "rather than resolved silently.",
     confidentialityClass: "public",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 2,
   }),
   defineAIPractice({
@@ -55,13 +67,13 @@ export const aiPractices = [
     activity: "Scoped implementation",
     purpose: "Write code for one well-defined task at a time, with tests written first.",
     humanResponsibility:
-      "DRAFT PLACEHOLDER: Randi reviews every change before it is committed and rejects work " +
-      "that does not match the requirement.",
+      "Randi reviews every change before it is committed and rejects work that does not " +
+      "match the requirement.",
     verificationMethod:
-      "DRAFT PLACEHOLDER: lint, type check, unit tests, and a production build must pass before " +
-      "a change is proposed for merge.",
+      "Lint, type check, unit tests, and a production build must pass before a change is " +
+      "proposed for merge.",
     confidentialityClass: "public",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 3,
   }),
   defineAIPractice({
@@ -70,16 +82,18 @@ export const aiPractices = [
     activity: "Verification and debugging",
     purpose: "Reproduce defects, narrow causes, and confirm fixes with regression coverage.",
     humanResponsibility:
-      "DRAFT PLACEHOLDER: Randi decides whether a fix is correct and whether the regression " +
-      "coverage is sufficient.",
+      "Randi decides whether a fix is correct and whether the regression coverage is sufficient.",
     verificationMethod:
-      "DRAFT PLACEHOLDER: end-to-end and accessibility checks run against a production build, " +
-      "and production behaviour is confirmed manually after deployment.",
+      "End-to-end and accessibility checks run against a production build, and production " +
+      "behaviour is confirmed manually after deployment.",
     correctedAssumption:
-      "DRAFT PLACEHOLDER: an example where an incorrect AI assumption was identified and " +
-      "corrected, pending Product Owner selection.",
+      "The automated accessibility gate was configured to fail only on critical and serious " +
+      "findings. Missing page headings are rated moderate, so two routes reached production with " +
+      "no primary heading at all. A scanner's severity ranking describes how badly a rule breaks " +
+      "a page in general; it does not know which requirements a given project treats as " +
+      "launch-blocking. The threshold was corrected and the gap covered by a regression test.",
     confidentialityClass: "public",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 4,
   }),
 ];

--- a/src/content/skills.ts
+++ b/src/content/skills.ts
@@ -1,18 +1,25 @@
 import { defineSkill } from "@/domain/content/define";
 
 /**
- * Technical Skills — DRAFT.
+ * Technical Skills — PUBLISHED.
  *
- * The skill names below are drawn from the technology stack the approved
- * documents already reference, so they are structurally real rather than
- * invented. Their *classification* is the open question (OPEN-004): whether
- * each is a strong working skill, professional experience, or currently
- * learning is Randi's judgement to make in P30, and FAC-SKILL-002 requires it
- * to be evidence-backed.
+ * The skill names are drawn from the technology stack the approved documents
+ * already reference, so they are structurally real rather than invented. The
+ * open question was always the *classification* (OPEN-004) — whether each is a
+ * strong working skill, professional experience, or currently learning is
+ * Randi's judgement, and FAC-SKILL-002 requires it to be evidence-backed.
  *
- * Everything is Draft, so nothing renders until that classification is
- * confirmed. There are no percentages, progress bars, or star ratings anywhere
- * in the model (FAC-SKILL-003).
+ * He confirmed every classification as assigned on 2026-08-08, which resolves
+ * OPEN-004. No classification changed; the review is what was missing, not the
+ * values.
+ *
+ * Docker stays "currently-learning" deliberately. Containerisation is a
+ * post-launch phase that has not been built yet, so any stronger claim would be
+ * one this repository cannot support.
+ *
+ * There are no percentages, progress bars, or star ratings anywhere in the
+ * model (FAC-SKILL-003) — a self-assigned number implies a precision nobody
+ * can defend in an interview.
  */
 export const skills = [
   defineSkill({
@@ -20,7 +27,7 @@ export const skills = [
     name: "TypeScript",
     group: "languages",
     classification: "strong-working-skill",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 1,
   }),
   defineSkill({
@@ -28,7 +35,7 @@ export const skills = [
     name: "Node.js",
     group: "backend",
     classification: "strong-working-skill",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 2,
   }),
   defineSkill({
@@ -36,7 +43,7 @@ export const skills = [
     name: "React",
     group: "frontend",
     classification: "professional-experience",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 3,
   }),
   defineSkill({
@@ -44,7 +51,7 @@ export const skills = [
     name: "Next.js",
     group: "frontend",
     classification: "professional-experience",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 4,
   }),
   defineSkill({
@@ -52,7 +59,7 @@ export const skills = [
     name: "MongoDB",
     group: "databases",
     classification: "professional-experience",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 5,
   }),
   defineSkill({
@@ -60,7 +67,7 @@ export const skills = [
     name: "GraphQL",
     group: "apis-and-integration",
     classification: "professional-experience",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 6,
   }),
   defineSkill({
@@ -68,7 +75,7 @@ export const skills = [
     name: "REST APIs",
     group: "apis-and-integration",
     classification: "strong-working-skill",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 7,
   }),
   defineSkill({
@@ -76,7 +83,7 @@ export const skills = [
     name: "Docker",
     group: "infrastructure-and-deployment",
     classification: "currently-learning",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 8,
   }),
   defineSkill({
@@ -84,7 +91,7 @@ export const skills = [
     name: "Vitest",
     group: "testing-and-quality",
     classification: "professional-experience",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 9,
   }),
   defineSkill({
@@ -92,7 +99,7 @@ export const skills = [
     name: "Playwright",
     group: "testing-and-quality",
     classification: "professional-experience",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 10,
   }),
   defineSkill({
@@ -100,7 +107,7 @@ export const skills = [
     name: "Git",
     group: "developer-tools",
     classification: "strong-working-skill",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 11,
   }),
   defineSkill({
@@ -108,7 +115,7 @@ export const skills = [
     name: "AI-Assisted Engineering",
     group: "ai-assisted-engineering",
     classification: "strong-working-skill",
-    publicationStatus: "draft",
+    publicationStatus: "published",
     sortOrder: 12,
   }),
 ];

--- a/tests/components/homepage-empty-state.test.tsx
+++ b/tests/components/homepage-empty-state.test.tsx
@@ -19,12 +19,12 @@ import { SkillsSection } from "@/components/sections/skills-section";
  * content, so each transition is a reviewed diff.
  */
 describe("sections with no eligible content omit themselves entirely", () => {
+  // Technical Skills and AI-Assisted Engineering left this list when Randi
+  // confirmed their content on 2026-08-08. They are asserted positively below.
   const emptySections = [
     ["Hero", HeroSection],
     ["About", AboutSection],
     ["Work Experience", ExperienceSection],
-    ["Technical Skills", SkillsSection],
-    ["AI-Assisted Engineering", AIWorkflowSection],
   ] as const;
 
   for (const [name, Section] of emptySections) {
@@ -76,5 +76,74 @@ describe("Selected Projects renders the one published project", () => {
 
     expect(container.textContent).not.toMatch(/coming soon/i);
     expect(screen.getAllByRole("article")).toHaveLength(1);
+  });
+});
+
+describe("Technical Skills renders the confirmed classifications", () => {
+  it("renders the section with its heading", () => {
+    render(<SkillsSection />);
+
+    expect(screen.getByRole("heading", { name: /technical skills/i })).toBeVisible();
+  });
+
+  it("renders skills as readable names, grouped", () => {
+    render(<SkillsSection />);
+
+    expect(screen.getByText("TypeScript")).toBeVisible();
+    expect(screen.getByText("Docker")).toBeVisible();
+  });
+
+  /**
+   * FAC-SKILL-003. A self-assigned percentage implies a precision nobody can
+   * defend in an interview, so the model has no field for one — this asserts
+   * none appears by any other route either.
+   */
+  it("shows no percentage, progress bar, or star rating", () => {
+    const { container } = render(<SkillsSection />);
+
+    expect(container.textContent).not.toMatch(/\d+\s*%/);
+    expect(container.textContent).not.toMatch(/[★☆]/);
+    expect(container.querySelector("progress, meter, [role='progressbar']")).toBeNull();
+  });
+});
+
+describe("AI-Assisted Engineering renders the four-step workflow", () => {
+  it("renders all four steps in the approved order", () => {
+    render(<AIWorkflowSection />);
+
+    for (const activity of [
+      /repository and requirement analysis/i,
+      /implementation planning/i,
+      /scoped implementation/i,
+      /verification and debugging/i,
+    ]) {
+      expect(screen.getByText(activity)).toBeVisible();
+    }
+  });
+
+  /**
+   * FAC-AI-002, and the reason this section exists at all. Presenting AI as
+   * the owner of final technical decisions is the failure mode; every step must
+   * therefore state a human responsibility and a verification method.
+   */
+  it("states a human responsibility for every step", () => {
+    const { container } = render(<AIWorkflowSection />);
+
+    expect(container.textContent).toMatch(/Randi confirms the analysis/);
+    expect(container.textContent).toMatch(/Randi owns the architecture/);
+    expect(container.textContent).toMatch(/Randi reviews every change/);
+    expect(container.textContent).toMatch(/Randi decides whether a fix is correct/);
+  });
+
+  it("records a corrected assumption rather than only successes", () => {
+    const { container } = render(<AIWorkflowSection />);
+
+    expect(container.textContent).toMatch(/accessibility gate/i);
+  });
+
+  it("leaves no draft marker in the published section", () => {
+    const { container } = render(<AIWorkflowSection />);
+
+    expect(container.textContent).not.toMatch(/DRAFT\s+PLACEHOLDER/);
   });
 });

--- a/tests/content/selectors-real-content.test.ts
+++ b/tests/content/selectors-real-content.test.ts
@@ -84,16 +84,46 @@ describe("remaining content is still Draft", () => {
     expect(getPublishedExperience()).toEqual([]);
   });
 
-  it("exposes no skill groups", () => {
-    expect(getPublishedSkillGroups()).toEqual([]);
-  });
-
-  it("exposes no AI practices", () => {
-    expect(getPublishedAIPractices()).toEqual([]);
-  });
-
   it("exposes no active resume, so Resume actions render their unavailable state", () => {
     expect(getActiveResume()).toBeNull();
+  });
+});
+
+/**
+ * Skills and AI practices went public on 2026-08-08, when Randi confirmed the
+ * classifications and the workflow wording. Neither required new copy — the
+ * review was what was missing, not the content.
+ */
+describe("skills and AI practices are public", () => {
+  it("exposes every skill, grouped", () => {
+    const groups = getPublishedSkillGroups();
+
+    expect(groups.length).toBeGreaterThan(0);
+    expect(groups.flatMap((group) => group.skills)).toHaveLength(12);
+  });
+
+  it("omits no group it returns", () => {
+    // FAC-HOME-005: an announced-but-empty group is worse than an absent one.
+    for (const group of getPublishedSkillGroups()) {
+      expect(group.skills.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("exposes the four workflow steps in order", () => {
+    expect(getPublishedAIPractices().map((practice) => practice.sortOrder)).toEqual([1, 2, 3, 4]);
+  });
+
+  /**
+   * FAC-AI-002. The schema makes these required, so this guards the stronger
+   * claim: that no published practice leaves either one blank or unreviewed.
+   */
+  it("gives every practice a human responsibility and a verification method", () => {
+    for (const practice of getPublishedAIPractices()) {
+      expect(practice.humanResponsibility.trim().length, practice.id).toBeGreaterThan(0);
+      expect(practice.verificationMethod.trim().length, practice.id).toBeGreaterThan(0);
+      expect(practice.humanResponsibility, practice.id).not.toMatch(/DRAFT\s+PLACEHOLDER/);
+      expect(practice.verificationMethod, practice.id).not.toMatch(/DRAFT\s+PLACEHOLDER/);
+    }
   });
 });
 


### PR DESCRIPTION
## Purpose

Close two launch blockers. **Neither required a word of new copy** — both records were already complete and accurate; what was missing was your confirmation, which you gave in this session.

**Release blockers: 7 → 5.**

## What changed, and what deliberately didn't

**Technical Skills.** The names were always real, drawn from the stack the approved documents reference. The open question was OPEN-004 — whether each classification is evidence-backed, which FAC-SKILL-002 makes your judgement alone. You confirmed all twelve as assigned, so **no classification changed**.

Docker stays `currently-learning` on purpose. Containerisation is a post-launch phase that has not been built, so anything stronger would be a claim this repository cannot support.

**AI-Assisted Engineering.** All four steps carried `DRAFT PLACEHOLDER:` prefixes on `humanResponsibility` and `verificationMethod` — but the sentences *after* the prefixes were already accurate descriptions of how the work ran. The markers are gone; the text is otherwise unchanged. A review outcome, not authorship.

**`correctedAssumption`** was the one genuinely empty field. It now records a real case from this repository, the one you picked from four:

> The accessibility gate was configured to fail only on critical and serious findings. Missing page headings are rated *moderate*, so two routes reached production with no primary heading at all.

A workflow section reporting only successes is worth nothing to an interviewer. This one names a threshold I set wrongly.

## Five tests failed, as designed

They were written to be brittle so a publication is always a reviewed diff. Updated rather than deleted, and **strengthened while open**:

- Skills: no percentage, progress bar, or star rating appears by any route (FAC-SKILL-003) — the model has no field for one, this checks nothing sneaks in another way
- AI practices: every published step states **both** a human responsibility and a verification method, with no draft marker surviving (FAC-AI-002 — presenting AI as owner of final decisions is the failure mode this section exists to avoid)
- Four steps assert their approved order

## Changed areas

| File | Change |
|---|---|
| `src/content/skills.ts` | 12 records → `published`; header records the OPEN-004 resolution |
| `src/content/ai-practices.ts` | 4 records → `published`; markers stripped; `correctedAssumption` filled |
| `tests/components/homepage-empty-state.test.tsx` | Skills and AI Workflow move from omitted to positively asserted |
| `tests/content/selectors-real-content.test.ts` | Same, at the selector layer |

## Tests and commands run

- `npm run validate:content` — passes: 2 projects, 1 experience, **12 skills, 4 AI practices**
- `npm run check` — exit 0, **310 tests**
- `npx playwright test` — **137 passed**, 1 skipped, Chromium + Firefox + WebKit
- `npm run validate:release` — exit 1 with **5** blockers, down from 7

Production build probe: both sections render, exactly one `h1`, **zero** `DRAFT PLACEHOLDER` strings in the HTML, `correctedAssumption` present.

## Known limitations

The homepage still has no Hero — the profile is Draft, so `getPublishedProfile()` returns null and the page opens on Selected Projects. Unchanged by this PR.

## Deployment impact

Two new homepage sections become visible: Technical Skills and AI-Assisted Engineering. The site still carries `noindex` and is not launch-ready.

## Rollback notes

`git revert` returns both content types to Draft and both sections disappear. The five tests would fail again, so a revert cannot land quietly.

## Confidentiality review

Pass. Skills are public technology names. The AI practices describe this repository's own workflow — no employer, client, or system is named, and no raw AI session is included (FAC-AI-003). `correctedAssumption` describes a defect in this public repository.

## FAC/NFAC references

FAC-SKILL-001, FAC-SKILL-002, FAC-SKILL-003, FAC-AI-001, FAC-AI-002, FAC-AI-003, FAC-HOME-005, NFAC-CONTENT-004
