### PR TITLE
test: cover the launch indexing switch and the ordering tie-breakers

### DIFF
--- a/tests/domain/launch-indexing.test.ts
+++ b/tests/domain/launch-indexing.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * What actually happens when the site becomes launch-ready.
+ *
+ * isPubliclyLaunchReady() is already tested in both directions. Its
+ * *consequences* were not: every existing check runs against real content,
+ * which is not launch-ready, so only the pre-launch branch of the indexing
+ * logic had ever executed. The branch that lets search engines in — the one
+ * that matters on launch day and never before it — was unreached code.
+ *
+ * That is the same shape as the defects the release audit found: a path that
+ * exists, looks correct, and has never once been run. These tests run it.
+ */
+
+const originalSiteUrl = process.env.SITE_URL;
+
+beforeEach(() => {
+  process.env.SITE_URL = "https://example.com";
+});
+
+afterEach(() => {
+  vi.resetModules();
+
+  if (originalSiteUrl === undefined) {
+    delete process.env.SITE_URL;
+  } else {
+    process.env.SITE_URL = originalSiteUrl;
+  }
+});
+
+const baseProject = {
+  publicationStatus: "published",
+  confidentialityClass: "public",
+  featured: true,
+  updatedAt: "2026-01-01",
+  title: "Project",
+  summary: "Summary.",
+  technologyIds: [],
+};
+
+/** Mock content into a launch-ready or not-launch-ready state (DEC-030). */
+function mockContent({ launchReady }: { launchReady: boolean }): void {
+  vi.resetModules();
+  vi.doMock("@/content/profile", () => ({
+    profile: {
+      id: "profile-a",
+      publicationStatus: launchReady ? "published" : "draft",
+    },
+  }));
+  vi.doMock("@/content/projects", () => ({
+    projects: Array.from({ length: launchReady ? 2 : 1 }, (_, index) => ({
+      ...baseProject,
+      id: `p-${index}`,
+      slug: `slug-${index}`,
+      featuredPriority: index + 1,
+    })),
+  }));
+}
+
+describe("robots.txt reverses itself at launch", () => {
+  it("refuses all crawling before launch", async () => {
+    mockContent({ launchReady: false });
+
+    const { default: robots } = await import("@/app/robots");
+
+    expect(robots().rules).toMatchObject({ userAgent: "*", disallow: "/" });
+  });
+
+  it("allows crawling once launch-ready", async () => {
+    mockContent({ launchReady: true });
+
+    const { default: robots } = await import("@/app/robots");
+
+    expect(robots().rules).toMatchObject({ userAgent: "*", allow: "/" });
+  });
+
+  it("advertises the sitemap only once there is something to crawl", async () => {
+    mockContent({ launchReady: false });
+    const { default: preLaunch } = await import("@/app/robots");
+
+    expect(preLaunch().sitemap).toBeUndefined();
+
+    mockContent({ launchReady: true });
+    const { default: launched } = await import("@/app/robots");
+
+    expect(launched().sitemap).toBe("https://example.com/sitemap.xml");
+  });
+
+  /**
+   * DEC-047. A disallow entry publishes the existence of the very path it is
+   * meant to hide, so unpublished slugs must never appear here — before or
+   * after launch. Their routes are never generated; there is nothing to hide.
+   */
+  it("names no unpublished path in either state", async () => {
+    for (const launchReady of [false, true]) {
+      mockContent({ launchReady });
+
+      const { default: robots } = await import("@/app/robots");
+      const serialized = JSON.stringify(robots());
+
+      expect(serialized, `launchReady=${launchReady}`).not.toMatch(
+        /jury|draft|private|restricted/i,
+      );
+    }
+  });
+});
+
+describe("page metadata reverses itself at launch", () => {
+  it("carries noindex before launch, because robots.txt alone does not prevent indexing", async () => {
+    mockContent({ launchReady: false });
+
+    const { buildRootMetadata } = await import("@/domain/metadata/build-metadata");
+
+    expect(buildRootMetadata().robots).toMatchObject({
+      index: false,
+      follow: false,
+      nocache: true,
+    });
+  });
+
+  /**
+   * The branch that had never run. If this were wrong, nothing would reveal it
+   * until the day the site was meant to become discoverable.
+   */
+  it("becomes indexable once launch-ready", async () => {
+    mockContent({ launchReady: true });
+
+    const { buildRootMetadata } = await import("@/domain/metadata/build-metadata");
+
+    expect(buildRootMetadata().robots).toMatchObject({ index: true, follow: true });
+  });
+
+  it("does not leave nocache set once indexable", async () => {
+    mockContent({ launchReady: true });
+
+    const { buildRootMetadata } = await import("@/domain/metadata/build-metadata");
+    const robots = buildRootMetadata().robots;
+
+    // nocache tells crawlers not to store a copy. Leaving it on after launch
+    // would suppress the cached preview a recruiter may see in results.
+    expect(robots).not.toHaveProperty("nocache", true);
+  });
+});

--- a/tests/domain/selector-ordering.test.ts
+++ b/tests/domain/selector-ordering.test.ts
@@ -1,0 +1,238 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * Ordering tie-breakers, and the guard on technology lookup.
+ *
+ * These branches were unreached. Real content has one Published project and no
+ * Published experience, so no comparison ever got past the first tie-break —
+ * the fallbacks that make ordering deterministic had never run.
+ *
+ * Determinism is not cosmetic here. Project order drives static route
+ * generation and sitemap order, so an unstable comparator would produce a
+ * build whose output depends on registration order rather than on the approved
+ * rules (FAC-PROJECTS-003).
+ */
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+const baseProject = {
+  publicationStatus: "published",
+  confidentialityClass: "public",
+  featured: false,
+  summary: "Summary.",
+  technologyIds: [],
+};
+
+async function loadWithProjects(projects: readonly unknown[]) {
+  vi.resetModules();
+  vi.doMock("@/content/projects", () => ({ projects }));
+
+  return import("@/domain/content/selectors");
+}
+
+describe("project ordering falls through to a stable tie-break", () => {
+  it("orders by featured priority first, unfeatured last", async () => {
+    const { getPublishedProjects } = await loadWithProjects([
+      { ...baseProject, id: "c", slug: "c", title: "C", updatedAt: "2026-01-01" },
+      {
+        ...baseProject,
+        id: "a",
+        slug: "a",
+        title: "A",
+        updatedAt: "2026-01-01",
+        featured: true,
+        featuredPriority: 1,
+      },
+      {
+        ...baseProject,
+        id: "b",
+        slug: "b",
+        title: "B",
+        updatedAt: "2026-01-01",
+        featured: true,
+        featuredPriority: 2,
+      },
+    ]);
+
+    expect(getPublishedProjects().map((project) => project.slug)).toEqual(["a", "b", "c"]);
+  });
+
+  it("falls back to recency when priority ties", async () => {
+    const { getPublishedProjects } = await loadWithProjects([
+      { ...baseProject, id: "old", slug: "old", title: "A", updatedAt: "2025-01-01" },
+      { ...baseProject, id: "new", slug: "new", title: "Z", updatedAt: "2026-06-01" },
+    ]);
+
+    // Most recently updated first, and deliberately against alphabetical order
+    // so a comparator that skipped to the title would fail here.
+    expect(getPublishedProjects().map((project) => project.slug)).toEqual(["new", "old"]);
+  });
+
+  it("falls back to title when priority and recency both tie", async () => {
+    const { getPublishedProjects } = await loadWithProjects([
+      { ...baseProject, id: "z", slug: "zebra", title: "Zebra", updatedAt: "2026-01-01" },
+      { ...baseProject, id: "a", slug: "alpha", title: "Alpha", updatedAt: "2026-01-01" },
+    ]);
+
+    expect(getPublishedProjects().map((project) => project.slug)).toEqual(["alpha", "zebra"]);
+  });
+
+  it("treats a featured project with no priority as unfeatured for ordering", async () => {
+    const { getPublishedProjects } = await loadWithProjects([
+      {
+        ...baseProject,
+        id: "n",
+        slug: "no-priority",
+        title: "A",
+        updatedAt: "2026-01-01",
+        featured: true,
+      },
+      {
+        ...baseProject,
+        id: "p",
+        slug: "with-priority",
+        title: "Z",
+        updatedAt: "2026-01-01",
+        featured: true,
+        featuredPriority: 3,
+      },
+    ]);
+
+    expect(getPublishedProjects().map((project) => project.slug)).toEqual([
+      "with-priority",
+      "no-priority",
+    ]);
+  });
+
+  it("is stable — the same input always produces the same order", async () => {
+    const build = (order: readonly string[]) =>
+      order.map((title) => ({
+        ...baseProject,
+        id: title,
+        slug: title.toLowerCase(),
+        title,
+        updatedAt: "2026-01-01",
+      }));
+
+    const forwards = await loadWithProjects(build(["A", "B", "C"]));
+    const first = forwards.getPublishedProjects().map((project) => project.slug);
+
+    const backwards = await loadWithProjects(build(["C", "B", "A"]));
+    const second = backwards.getPublishedProjects().map((project) => project.slug);
+
+    // Registration order must not leak into the output.
+    expect(second).toEqual(first);
+  });
+});
+
+const baseExperience = {
+  publicationStatus: "published",
+  confidentialityClass: "sanitized",
+  companyName: "Company",
+  position: "Role",
+  summary: "Summary.",
+  responsibilities: ["Did work."],
+  isCurrent: false,
+  sortOrder: 1,
+};
+
+async function loadWithExperience(records: readonly unknown[]) {
+  vi.resetModules();
+  vi.doMock("@/content/experience", () => ({ experience: records }));
+
+  return import("@/domain/content/selectors");
+}
+
+describe("experience ordering", () => {
+  it("puts a current role first regardless of dates", async () => {
+    const { getPublishedExperience } = await loadWithExperience([
+      { ...baseExperience, id: "past", startDate: "2030-01-01", endDate: "2031-01-01" },
+      { ...baseExperience, id: "now", startDate: "2020-01-01", isCurrent: true },
+    ]);
+
+    expect(getPublishedExperience().map((record) => record.id)).toEqual(["now", "past"]);
+  });
+
+  it("orders non-current roles most recent first", async () => {
+    const { getPublishedExperience } = await loadWithExperience([
+      { ...baseExperience, id: "older", startDate: "2019-01-01", endDate: "2020-01-01" },
+      { ...baseExperience, id: "newer", startDate: "2022-01-01", endDate: "2023-01-01" },
+    ]);
+
+    expect(getPublishedExperience().map((record) => record.id)).toEqual(["newer", "older"]);
+  });
+
+  it("falls back to sortOrder when start dates tie", async () => {
+    const { getPublishedExperience } = await loadWithExperience([
+      {
+        ...baseExperience,
+        id: "second",
+        startDate: "2022-01-01",
+        endDate: "2023-01-01",
+        sortOrder: 2,
+      },
+      {
+        ...baseExperience,
+        id: "first",
+        startDate: "2022-01-01",
+        endDate: "2023-01-01",
+        sortOrder: 1,
+      },
+    ]);
+
+    expect(getPublishedExperience().map((record) => record.id)).toEqual(["first", "second"]);
+  });
+});
+
+describe("getTechnologyNames", () => {
+  async function loadWithSkills(skills: readonly unknown[]) {
+    vi.resetModules();
+    vi.doMock("@/content/skills", () => ({ skills }));
+
+    return import("@/domain/content/selectors");
+  }
+
+  const publishedSkill = {
+    id: "skill-a",
+    name: "Alpha",
+    group: "languages",
+    classification: "strong-working-skill",
+    publicationStatus: "published",
+    sortOrder: 1,
+  };
+
+  it("returns nothing for undefined or empty ids", async () => {
+    const { getTechnologyNames } = await loadWithSkills([publishedSkill]);
+
+    expect(getTechnologyNames(undefined)).toEqual([]);
+    expect(getTechnologyNames([])).toEqual([]);
+  });
+
+  it("resolves ids to readable names", async () => {
+    const { getTechnologyNames } = await loadWithSkills([publishedSkill]);
+
+    expect(getTechnologyNames(["skill-a"])).toEqual(["Alpha"]);
+  });
+
+  /**
+   * The confidentiality-relevant case. A tag must never fall back to rendering
+   * a raw id, and must never surface a skill that is not published — either
+   * would leak content the selector layer exists to withhold.
+   */
+  it("omits unknown ids rather than rendering them", async () => {
+    const { getTechnologyNames } = await loadWithSkills([publishedSkill]);
+
+    expect(getTechnologyNames(["skill-a", "skill-does-not-exist"])).toEqual(["Alpha"]);
+  });
+
+  it("omits Draft skills", async () => {
+    const { getTechnologyNames } = await loadWithSkills([
+      publishedSkill,
+      { ...publishedSkill, id: "skill-draft", name: "Hidden", publicationStatus: "draft" },
+    ]);
+
+    expect(getTechnologyNames(["skill-a", "skill-draft"])).toEqual(["Alpha"]);
+  });
+});


### PR DESCRIPTION
## Purpose

A coverage sweep of the correctness-critical layer found `src/domain` at 86.85% branch. Two of the gaps matter far more than the number does.

## Gap 1 — the indexing switch had never run

`isPubliclyLaunchReady()` was already tested in both directions. **Its consequences were not.**

Every existing check runs against real content, which is not launch-ready, so only the pre-launch branch of `robots.ts` and `buildRootMetadata` had ever executed. **`src/app/robots.ts` had no unit test at all.**

The branch that lets search engines in only matters on launch day — and by then it is too late to discover it is wrong.

That is the same shape as three of the four defects the release audit found: a path that exists, reads correctly, and has never once been run. These tests run it.

Also asserted:
- The sitemap is advertised **only** after launch
- `nocache` does not survive the switch — leaving it on would suppress the cached preview a recruiter may see in results
- **DEC-047 in both states**, not just before launch: a disallow entry publishes the existence of the path it is meant to hide, so no unpublished slug may appear in `robots.txt` at any point

## Gap 2 — no comparison had ever reached a tie-break

Real content has one Published project and no Published experience, so the fallbacks that make ordering deterministic had never run.

Ordering is not cosmetic: it drives **static route generation and sitemap order**. An unstable comparator would make build output depend on registration order rather than the approved rules. There is now a test that the same set, registered in reverse, produces the same result.

`getTechnologyNames` gains its confidentiality case: an unknown id is **omitted rather than rendered raw**, and a Draft skill never surfaces through a technology tag.

## Mutation-checked, not trusted

Mocked tests are exactly the kind that can pass because the mock silently didn't apply. Inverting the launch-ready condition in **both** `robots.ts` and `build-metadata.ts`:

- **6 of 7 fail.** The survivor is the DEC-047 invariant, which is correct in both states by design.

## Coverage

| | Before | After |
|---|---|---|
| `selectors.ts` statements | 84.44% | **100%** |
| `selectors.ts` branch | 64.28% | **90.47%** |
| `src/domain` branch | 86.85% | **92.01%** |
| All files branch | 74.86% | 78.10% |

**No test was added to move a number.** Each covers a branch that had never executed. Per the plan's P24, coverage is a gap-finding tool here, not a target — the remaining uncovered lines in `selectors.ts` are sub-branches of ternaries with no distinct behaviour.

## Changed areas

| File | Change |
|---|---|
| `tests/domain/launch-indexing.test.ts` | New. 7 tests — both branches of `robots.ts` and root metadata |
| `tests/domain/selector-ordering.test.ts` | New. 12 tests — project and experience tie-breakers, technology name resolution |

Test-only. No source file touched.

## Tests and commands run

- `npm run check` — exit 0, **329 tests** (19 new)
- `npx playwright test` — **137 passed**, 1 skipped, Chromium + Firefox + WebKit
- Mutation check on the launch condition, as above

## Known limitations

These tests mock content to reach the launch-ready state. They prove the switch behaves correctly; they do not prove the real content will be launch-ready — that is `validate:release`'s job, and it still reports 5 blockers.

## Deployment impact

None. No source change.

## Rollback notes

`git revert` removes 19 tests and returns the launch branch to unreached code. No runtime effect.

## Confidentiality review

Pass. Fixtures use synthetic ids and `example.com`.

## FAC/NFAC references

FAC-PROJECTS-003, FAC-EXP-001, FAC-PUBLISH-001, DEC-030, DEC-047, NFAC-SEO-001, NFAC-SEO-002, NFAC-SEC-006, NFAC-TEST-002
