### PR TITLE
test: cover the project detail components, including the responsibility split

### DIFF
--- a/tests/components/project-detail-components.test.tsx
+++ b/tests/components/project-detail-components.test.tsx
@@ -1,0 +1,240 @@
+import { render, screen, within } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { ProjectNavigation } from "@/components/project/project-navigation";
+import { ProjectResponsibility } from "@/components/project/project-responsibility";
+import { ProjectSection } from "@/components/project/project-section";
+import type { ProjectCaseStudy } from "@/domain/content/schemas";
+import { ROUTES, SECTION_IDS } from "@/lib/constants";
+
+/**
+ * The Project Detail building blocks.
+ *
+ * All three were at zero unit coverage. The detail page exercises them through
+ * end-to-end tests, but only in the one configuration the current content
+ * happens to produce — a solo personal project with no neighbours. Every other
+ * branch, including the one that separates team work from Randi's own, had
+ * never rendered.
+ */
+
+/* ------------------------------------------------------------------------- */
+/* ProjectResponsibility                                                      */
+/* ------------------------------------------------------------------------- */
+
+/**
+ * FAC-PROJECT-003 and NFAC-CONTENT-002. This is a truthfulness control, not a
+ * layout preference: a merged list silently attributes a team's work to the
+ * author, and a technical interviewer probing ownership is exactly who reads
+ * this section.
+ */
+describe("ProjectResponsibility keeps team work separable from personal work", () => {
+  it("always renders the personal block", () => {
+    render(<ProjectResponsibility personal={["Designed the schema."]} team={undefined} />);
+
+    expect(screen.getByRole("heading", { name: /my responsibility/i })).toBeVisible();
+    expect(screen.getByText("Designed the schema.")).toBeVisible();
+  });
+
+  it("omits the team block entirely for solo work", () => {
+    render(<ProjectResponsibility personal={["Did it all."]} team={undefined} />);
+
+    expect(screen.queryByRole("heading", { name: /team or external/i })).not.toBeInTheDocument();
+  });
+
+  it("omits the team block for an empty list rather than rendering an empty heading", () => {
+    render(<ProjectResponsibility personal={["Did it all."]} team={[]} />);
+
+    expect(screen.queryByRole("heading", { name: /team or external/i })).not.toBeInTheDocument();
+  });
+
+  it("renders both blocks with distinct headings when team work exists", () => {
+    render(
+      <ProjectResponsibility personal={["I wrote the parser."]} team={["The team ran QA."]} />,
+    );
+
+    expect(screen.getByRole("heading", { name: /my responsibility/i })).toBeVisible();
+    expect(screen.getByRole("heading", { name: /team or external responsibility/i })).toBeVisible();
+  });
+
+  /**
+   * The assertion that actually enforces the requirement. Rendering both
+   * headings proves nothing if the items are pooled underneath them.
+   */
+  it("never lists team work under the personal heading", () => {
+    render(
+      <ProjectResponsibility personal={["I wrote the parser."]} team={["The team ran QA."]} />,
+    );
+
+    const lists = screen.getAllByRole("list");
+
+    expect(lists).toHaveLength(2);
+
+    const [personalList, teamList] = lists;
+
+    expect(within(personalList as HTMLElement).getByText("I wrote the parser.")).toBeVisible();
+    expect(within(personalList as HTMLElement).queryByText("The team ran QA.")).toBeNull();
+    expect(within(teamList as HTMLElement).getByText("The team ran QA.")).toBeVisible();
+    expect(within(teamList as HTMLElement).queryByText("I wrote the parser.")).toBeNull();
+  });
+
+  it("keeps its headings below the page heading (NFAC-A11Y-003)", () => {
+    const { container } = render(<ProjectResponsibility personal={["A."]} team={["B."]} />);
+
+    // The page h1 is the project title and section headings are h2, so these
+    // sit at h3. An h1 or h2 here would break the outline.
+    expect(container.querySelector("h1, h2")).toBeNull();
+    expect(container.querySelectorAll("h3")).toHaveLength(2);
+  });
+});
+
+/* ------------------------------------------------------------------------- */
+/* ProjectSection                                                             */
+/* ------------------------------------------------------------------------- */
+
+describe("ProjectSection omits itself when it has nothing to say", () => {
+  it("renders nothing without a body or children (FAC-PROJECT-006)", () => {
+    const { container } = render(<ProjectSection heading="Architecture" />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("announces no heading when omitted", () => {
+    const { container } = render(<ProjectSection heading="Architecture" body="" />);
+
+    // An empty string is as absent as undefined — a heading with nothing under
+    // it is worse for a screen-reader user than no section.
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders a markdown body", () => {
+    render(<ProjectSection heading="Outcome" body="The site **shipped**." />);
+
+    expect(screen.getByRole("heading", { level: 2, name: "Outcome" })).toBeVisible();
+    expect(screen.getByText("shipped")).toBeVisible();
+  });
+
+  it("renders children without a body", () => {
+    render(
+      <ProjectSection heading="Responsibility">
+        <p>Custom block.</p>
+      </ProjectSection>,
+    );
+
+    expect(screen.getByRole("heading", { level: 2, name: "Responsibility" })).toBeVisible();
+    expect(screen.getByText("Custom block.")).toBeVisible();
+  });
+
+  it("renders as h2, one level below the project title", () => {
+    const { container } = render(<ProjectSection heading="Context" body="Text." />);
+
+    expect(container.querySelector("h1")).toBeNull();
+    expect(container.querySelector("h2")).not.toBeNull();
+  });
+});
+
+/* ------------------------------------------------------------------------- */
+/* ProjectNavigation                                                          */
+/* ------------------------------------------------------------------------- */
+
+function projectStub(slug: string, title: string): ProjectCaseStudy {
+  return { slug, title } as unknown as ProjectCaseStudy;
+}
+
+describe("ProjectNavigation", () => {
+  it("always offers a way back to the index", () => {
+    render(<ProjectNavigation previous={null} next={null} resumeHref={null} contactHref={null} />);
+
+    expect(screen.getByRole("link", { name: /back to projects/i })).toHaveAttribute(
+      "href",
+      ROUTES.projects,
+    );
+  });
+
+  it("renders no neighbour links when there are no neighbours", () => {
+    render(<ProjectNavigation previous={null} next={null} resumeHref={null} contactHref={null} />);
+
+    expect(screen.queryByText(/previous project/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/next project/i)).not.toBeInTheDocument();
+  });
+
+  it("links a previous neighbour to its slug", () => {
+    render(
+      <ProjectNavigation
+        previous={projectStub("earlier", "Earlier Project")}
+        next={null}
+        resumeHref={null}
+        contactHref={null}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /earlier project/i })).toHaveAttribute(
+      "href",
+      "/projects/earlier",
+    );
+    expect(screen.queryByText(/next project/i)).not.toBeInTheDocument();
+  });
+
+  it("links a next neighbour to its slug", () => {
+    render(
+      <ProjectNavigation
+        previous={null}
+        next={projectStub("later", "Later Project")}
+        resumeHref={null}
+        contactHref={null}
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /later project/i })).toHaveAttribute(
+      "href",
+      "/projects/later",
+    );
+    expect(screen.queryByText(/previous project/i)).not.toBeInTheDocument();
+  });
+
+  it("offers no Resume action when none is active (FAC-RESUME-003)", () => {
+    render(<ProjectNavigation previous={null} next={null} resumeHref={null} contactHref={null} />);
+
+    expect(screen.queryByRole("link", { name: /resume/i })).not.toBeInTheDocument();
+  });
+
+  it("offers the Resume when one is active", () => {
+    render(
+      <ProjectNavigation previous={null} next={null} resumeHref="/resume.pdf" contactHref={null} />,
+    );
+
+    expect(screen.getByRole("link", { name: /view resume/i })).toHaveAttribute(
+      "href",
+      "/resume.pdf",
+    );
+  });
+
+  it("falls back to the contact section when no channel is Published", () => {
+    render(<ProjectNavigation previous={null} next={null} resumeHref={null} contactHref={null} />);
+
+    expect(screen.getByRole("link", { name: /^contact$/i })).toHaveAttribute(
+      "href",
+      `${ROUTES.home}#${SECTION_IDS.contact}`,
+    );
+  });
+
+  it("uses the Published contact channel when there is one", () => {
+    render(
+      <ProjectNavigation
+        previous={null}
+        next={null}
+        resumeHref={null}
+        contactHref="mailto:person@example.com"
+      />,
+    );
+
+    expect(screen.getByRole("link", { name: /^contact$/i })).toHaveAttribute(
+      "href",
+      "mailto:person@example.com",
+    );
+  });
+
+  it("labels itself so the landmark is distinguishable", () => {
+    render(<ProjectNavigation previous={null} next={null} resumeHref={null} contactHref={null} />);
+
+    expect(screen.getByRole("navigation", { name: /related project/i })).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Purpose

Three Project Detail components sat at **zero unit coverage**: `ProjectResponsibility`, `ProjectSection`, `ProjectNavigation`.

The detail page exercises all three end to end — but only in the single configuration the current content produces: a solo personal project with no neighbours. Every other branch had never rendered.

## The one that matters

`ProjectResponsibility` is the control that enforces FAC-PROJECT-003 and NFAC-CONTENT-002: **team or external work must never be presented as your own.**

That is a truthfulness mechanism, not a layout preference. A merged list silently attributes a team's work to the author, and a technical interviewer probing ownership is precisely who reads that section.

Asserting both headings render would prove nothing — the items could still be pooled underneath them. The test resolves the two lists **separately** and asserts neither contains the other's items.

**Mutation-checked:** merging the two arrays in the component fails that test and *only* that test — the other nineteen stay green. The assertion is aimed at the requirement, not at the markup around it.

## The rest

**`ProjectSection`** — omission cases. No body and no children renders nothing, and an empty string counts as absent, because a heading with nothing under it is worse for a screen-reader user than no section (FAC-PROJECT-006).

**`ProjectNavigation`** — every branch the current content cannot produce: previous neighbour, next neighbour, neither, active Resume, no Resume (FAC-RESUME-003), Published contact channel, and the fallback to the contact anchor. Plus its landmark label — an unlabelled `nav` is indistinguishable from the header for a screen-reader user.

**Heading levels asserted in both.** Responsibility headings are `h3`, section headings `h2`, under the project title's `h1`. That is the same class of defect that once shipped two routes with no `h1` at all.

## Coverage

| | Before | After |
|---|---|---|
| `components/project` statements | 50% | **100%** |
| `components/project` branch | 23.07% | **79.48%** |
| All files branch | 78.10% | **84.05%** |

## Changed areas

`tests/components/project-detail-components.test.tsx` — new, 20 tests. **Test-only; no source file touched.**

## Tests and commands run

- `npm run check` — exit 0, **349 tests** (20 new)
- `npx playwright test` — **137 passed**, 1 skipped, Chromium + Firefox + WebKit
- Mutation check on the responsibility split, as above

## Known limitations

The remaining branch gap in `project-card.tsx` is the optional project visual, which needs a Published media asset that does not exist yet. **Left uncovered rather than mocked into existence** — a test that invents a media asset to reach a branch proves the mock works, not the component. It closes naturally when the photograph and project visuals land in P30.

## Deployment impact

None. No source change.

## Rollback notes

`git revert` removes 20 tests and returns the responsibility split to unasserted. No runtime effect.

## Confidentiality review

Pass. Fixtures are synthetic (`"I wrote the parser."`, `example.com`). No real employer, project, or claim appears.

## FAC/NFAC references

FAC-PROJECT-003, FAC-PROJECT-006, FAC-PROJECT-008, FAC-RESUME-003, NFAC-CONTENT-002, NFAC-A11Y-003, NFAC-TEST-002
