### PR TITLE
test: assert markdown url handling and the rest of the heading scale

### DIFF
--- a/tests/components/ui-primitives.test.tsx
+++ b/tests/components/ui-primitives.test.tsx
@@ -204,4 +204,80 @@ describe("MarkdownContent", () => {
     expect(screen.queryByRole("heading", { level: 1 })).not.toBeInTheDocument();
     expect(screen.getByRole("heading", { level: 3 })).toBeInTheDocument();
   });
+
+  it("keeps the rest of the heading scale below the section heading", () => {
+    // Only `#` was covered. A `##` or `###` in content must not outrank the
+    // section either, and each maps to a different level.
+    const { unmount } = render(<MarkdownContent>{"## Second level"}</MarkdownContent>);
+
+    expect(screen.getByRole("heading", { level: 3, name: "Second level" })).toBeInTheDocument();
+    unmount();
+
+    render(<MarkdownContent>{"### Third level"}</MarkdownContent>);
+
+    expect(screen.getByRole("heading", { level: 4, name: "Third level" })).toBeInTheDocument();
+    expect(screen.queryByRole("heading", { level: 2 })).not.toBeInTheDocument();
+  });
+
+  /**
+   * URL scheme handling.
+   *
+   * react-markdown neutralises dangerous schemes by default, so these pass
+   * today without any code of ours. That is exactly why they are worth
+   * asserting: the protection is a library default, and a future
+   * `urlTransform` override or a `rehype-raw` addition would remove it with
+   * nothing to object.
+   */
+  it("neutralises a javascript: url in a content link", () => {
+    const { container } = render(
+      <MarkdownContent>{"[click](javascript:alert(1))"}</MarkdownContent>,
+    );
+
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("");
+  });
+
+  it("neutralises a data: url in a content link", () => {
+    const { container } = render(<MarkdownContent>{"[click](data:text/html,hi)"}</MarkdownContent>);
+
+    expect(container.querySelector("a")?.getAttribute("href")).toBe("");
+  });
+
+  it("leaves a relative link internal, with no new tab", () => {
+    // The branch opposite the external-link case: an in-site link must not be
+    // torn out into a new tab, and must not carry rel tokens it does not need.
+    const { container } = render(<MarkdownContent>{"[Projects](/projects)"}</MarkdownContent>);
+    const link = container.querySelector("a");
+
+    expect(link?.getAttribute("href")).toBe("/projects");
+    expect(link?.getAttribute("target")).toBeNull();
+  });
+
+  it("announces that an external content link opens a new tab", () => {
+    render(<MarkdownContent>{"[GitHub](https://github.com/randifajar)"}</MarkdownContent>);
+
+    // NFAC-A11Y-004: the icon is never the only indicator, so the accessible
+    // name has to carry it.
+    expect(screen.getByRole("link", { name: /opens in a new tab/i })).toBeInTheDocument();
+  });
+
+  it("lets a wide table scroll inside itself rather than the page (NFAC-RESP-001)", () => {
+    const { container } = render(
+      <MarkdownContent>{"| A | B |\n| --- | --- |\n| 1 | 2 |"}</MarkdownContent>,
+    );
+
+    const table = container.querySelector("table");
+
+    expect(table).not.toBeNull();
+    expect(table?.parentElement?.className).toContain("overflow-x-auto");
+  });
+
+  it("renders ordered lists, inline code, and blockquotes", () => {
+    const { container } = render(
+      <MarkdownContent>{"1. first\n2. second\n\n`npm run check`\n\n> Quoted."}</MarkdownContent>,
+    );
+
+    expect(container.querySelector("ol")?.querySelectorAll("li")).toHaveLength(2);
+    expect(screen.getByText("npm run check").tagName).toBe("CODE");
+    expect(container.querySelector("blockquote")?.textContent).toContain("Quoted.");
+  });
 });


### PR DESCRIPTION
## Purpose

`MarkdownContent` renders every long-form field on a case study and was the last component with a real coverage gap: **47% statements**, and only **60% of `components/ui` functions** were reached at all.

## The gap was quieter than the obvious one

The existing tests already covered `<script>`, `<img onerror>`, and `<iframe>` injection — the attacks you think of first.

What was never asserted: **a markdown link carrying a `javascript:` or `data:` URL.**

I probed it before writing anything. react-markdown neutralises both by default — `href=""`. So the protection is real, working, and **entirely dependent on a library default that nothing in this repository defended.**

That is exactly why it is worth asserting. It is not our code. Overriding `urlTransform` or adding `rehype-raw` would remove the protection silently, and the diff would look like a formatting option.

**Mutation-confirmed:** passing URLs through unchanged fails exactly the two new scheme tests and nothing else.

## The opposite branch was also unreached

Only absolute links had been tested. Nothing checked that a **relative link stays internal** — an in-site link torn out into a new tab is a defect in the other direction, and that branch had never run.

## Heading downgrades were half covered

A content `#` was asserted. `##` and `###` were not — even though each maps to a different level, and content headings must never outrank the page `h1` or the section `h2` (NFAC-A11Y-003).

## Also now covered

- The accessible disclosure that an external content link opens a new tab — the icon must never be the only indicator (NFAC-A11Y-004)
- A wide table scrolls **inside its own container** rather than forcing the page to scroll at 320px (NFAC-RESP-001)
- Ordered lists, inline code, and blockquotes — all used by case studies, none rendered by any test

## Coverage

| | Before | After |
|---|---|---|
| `components/ui` statements | 72.72% | **100%** |
| `components/ui` functions | 60% | **100%** |
| `components/ui` branch | 86.95% | 91.30% |
| **All files functions** | 94.66% | **100%** |
| All files statements | 96.19% | 97.90% |

## Changed areas

`tests/components/ui-primitives.test.tsx` — 7 tests added to the existing `MarkdownContent` block. **Test-only; no source file touched.**

## Tests and commands run

- `npm run check` — exit 0, **356 tests** (7 new)
- `npx playwright test` — **137 passed**, 1 skipped, Chromium + Firefox + WebKit
- Mutation check on `urlTransform`, as above

## Known limitations

The scheme tests assert `href=""`, which is react-markdown's current neutralisation shape. A future version could neutralise differently — omitting the attribute, say — and these would fail on a change that is still safe. That is the right failure direction: a loud test on a library upgrade beats a silent loss of sanitisation.

## Deployment impact

None. No source change.

## Rollback notes

`git revert` removes 7 tests and returns URL-scheme handling to unasserted. No runtime effect.

## Confidentiality review

Pass. Fixtures use `example.com` and the already-public GitHub URL.

## FAC/NFAC references

NFAC-SEC-003, NFAC-A11Y-003, NFAC-A11Y-004, NFAC-RESP-001, NFAC-TEST-002
