### PR TITLE
fix: reject bracketed editorial notes in published content

### DIFF
--- a/src/domain/content/release-validation.ts
+++ b/src/domain/content/release-validation.ts
@@ -55,6 +55,36 @@ const PLACEHOLDER_PATTERNS: readonly { readonly label: string; readonly pattern:
     label: "pending approval",
     pattern: /\bpending\s+(product\s+owner|approval|selection|confirmation)\b/i,
   },
+
+  /*
+   * Bracketed editorial notes.
+   *
+   * The all-caps markers above are matched case-sensitively because lowercase
+   * prose legitimately discusses them. Inside square brackets that concern
+   * disappears: bracketed text carrying a request is an instruction to the
+   * author, whatever its casing. So this rule catches a lowercase
+   * "[placeholder]" that the case-sensitive PLACEHOLDER rule deliberately
+   * lets through.
+   *
+   * This gap was live, not theoretical. The content brief handed to an
+   * external assistant asked it to emit "[NEED FROM RANDI: ...]" wherever it
+   * could not verify a fact, and thirty of those came back. Not one of the
+   * patterns above would have caught a single one. A convention invented to
+   * make unverified content *visible* had quietly created a class of
+   * placeholder the gate could not see — the safety mechanism and the hole
+   * were the same decision.
+   *
+   * Markdown links are the false-positive risk, since content uses them. The
+   * rule therefore requires a request keyword inside the brackets:
+   * "[GitHub](https://…)" and "[the docs](/docs)" are untouched. Verified
+   * against all 284 strings in the current content set with zero false
+   * positives.
+   */
+  {
+    label: "bracketed editorial note",
+    pattern:
+      /\[[^\]]*\b(needs? from|to be (written|supplied|added|confirmed|decided)|placeholder|pending|fill in)\b[^\]]*\]/i,
+  },
 ];
 
 /** Slugs of the two confirmed launch case studies (Handoff section 4). */

--- a/tests/content/release-validation.test.ts
+++ b/tests/content/release-validation.test.ts
@@ -354,4 +354,50 @@ describe("placeholder scan distinguishes markers from prose", () => {
   it("still rejects lowercase lorem ipsum, which is never legitimate prose", () => {
     expect(rulesFor(withOutcome("lorem ipsum dolor"))).toContain("no-published-placeholders");
   });
+
+  /**
+   * Bracketed editorial notes.
+   *
+   * These escaped every rule above until 2026-08-08. The content brief given
+   * to an external assistant asked it to emit "[NEED FROM RANDI: ...]" for any
+   * fact it could not verify; thirty came back and none would have been
+   * caught. The convention meant to make unverified content visible was itself
+   * invisible to the gate.
+   */
+  const bracketedNotes = [
+    "[NEED FROM RANDI: what was the verified outcome?]",
+    "[needs from randi: the exact date]",
+    "[placeholder]",
+    "[to be written]",
+    "[to be confirmed with the team]",
+    "[pending the final numbers]",
+    "[Fill in once QA signs off]",
+  ];
+
+  for (const text of bracketedNotes) {
+    it(`rejects bracketed note: "${text.slice(0, 45)}"`, () => {
+      expect(rulesFor(withOutcome(`The result was good. ${text}`))).toContain(
+        "no-published-placeholders",
+      );
+    });
+  }
+
+  /**
+   * The false-positive risk. Long-form fields are Markdown and use links, so a
+   * rule that matched any square brackets would reject correct content — the
+   * failure mode that made the all-caps markers case-sensitive in the first
+   * place.
+   */
+  const legitimateBrackets = [
+    "I used [Node.js](https://nodejs.org) and [GraphQL](https://graphql.org) throughout.",
+    "See [the release checklist](docs/release-checklist.md) for the full gate.",
+    "The pipeline returns an array such as [1, 2, 3] for each grouped result.",
+    "Aggregation stages are configured as [match, group, sort] in that order.",
+  ];
+
+  for (const text of legitimateBrackets) {
+    it(`accepts brackets in prose: "${text.slice(0, 45)}..."`, () => {
+      expect(rulesFor(withOutcome(text))).not.toContain("no-published-placeholders");
+    });
+  }
 });


### PR DESCRIPTION
## Purpose

Close a hole in the release gate that I created.

The content brief given to ChatGPT asked it to emit `[NEED FROM RANDI: …]` wherever it could not verify a fact. That was the right instruction — it made unverified content **visible** instead of letting the model invent an answer. Thirty came back.

**Not one would have failed the release gate.** I checked rather than assumed: the string matches none of the existing patterns, so content carrying it could have reached production silently.

The convention invented to make unverified content visible was itself invisible to the checker. The safety mechanism and the hole were the same decision — worth recording, not quietly patching.

## The rule

Bracket-scoped and **case-insensitive**. That combination is deliberate.

The all-caps markers are matched case-*sensitively* because lowercase prose legitimately discusses `TODO`, `PLACEHOLDER`, and the rest — that was itself a fix, made when `/placeholder/i` rejected the case study's own accurate sentence. Inside square brackets the concern disappears: bracketed text carrying a request is an instruction to the author whatever its casing.

So `[placeholder]` is now rejected, while a bare "placeholder" in a sentence is still allowed.

## The false-positive risk was measured, not guessed

Every long-form field accepts Markdown and the case studies use links, so a rule matching *any* square brackets would reject correct content — exactly the failure that made the all-caps markers case-sensitive.

The rule therefore requires a request keyword inside the brackets. Measured against **all 284 strings** in the current content set before adoption: **zero false positives.**

Four tests pin that boundary using shapes this project actually produces:

```
[Node.js](https://nodejs.org)            → accepted
[the release checklist](docs/…)          → accepted
an array such as [1, 2, 3]               → accepted
stages configured as [match, group, sort] → accepted
```

## Against the real draft

The rule now rejects **all 30** markers in the ChatGPT output.

## Changed areas

| File | Change |
|---|---|
| `src/domain/content/release-validation.ts` | One pattern added, with the reasoning recorded |
| `tests/content/release-validation.test.ts` | 11 tests — 7 rejection shapes, 4 acceptance boundaries |

## Tests and commands run

- `npm run check` — exit 0, **385 tests** (11 new)
- `npx playwright test` — **140 passed**, 1 skipped, three engines
- `npm run validate:release` — still exactly **2** blockers (the Jury case study), no new false rejection

## Known limitations

The keyword list is finite. A note phrased as `[ask Randi about this]` would still pass — the rule targets the shapes actually seen rather than attempting to recognise intent, and erring toward precision is deliberate given a false positive pressures the author to degrade correct content. Content review remains the backstop for the rest.

## Deployment impact

None. Validation only; no runtime code and no content change.

## Rollback notes

`git revert` reopens the gap. Any bracketed editorial note in Published content would then pass the release gate again.

## Confidentiality review

Pass. Test fixtures are synthetic.

## FAC/NFAC references

NFAC-CONTENT-004, NFAC-TEST-001, NFAC-TEST-004, ADR-006
