### PR TITLE
test: restore coverage of the homepage section omission path

### DIFF
--- a/tests/components/homepage-section-omission.test.tsx
+++ b/tests/components/homepage-section-omission.test.tsx
@@ -1,0 +1,99 @@
+import { render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * FAC-HOME-005 and UX 17: a section with nothing publicly eligible renders
+ * nothing at all, rather than a heading with an empty body. An
+ * announced-but-empty section is worse for a screen-reader user than an absent
+ * one.
+ *
+ * This behaviour used to be covered against real content, back when every
+ * section was Draft. Publishing the launch content removed the subject, and
+ * the previous change recorded the gap with the claim that testing it "would
+ * only assert the mock". That claim was wrong, and this file exists because of
+ * it.
+ *
+ * What is mocked here is the *content registry* — the raw modules under
+ * src/content. The real selectors run against them, and the real components
+ * run against the real selectors. Nothing about the omission decision is
+ * stubbed; the components are simply given a repository with nothing published
+ * in it. That is the same technique used for the launch-indexing and selector
+ * ordering branches, and it exercises production code rather than a stand-in.
+ *
+ * Mocking the *selectors* would have been the version worth refusing.
+ */
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+/** A profile that exists but is not publicly eligible. */
+const draftProfile = { id: "profile-a", publicationStatus: "draft" };
+
+/**
+ * Empty the content registry, then load a section through the real selector
+ * layer.
+ */
+async function renderWithEmptyContent(
+  moduleName: string,
+  componentName: string,
+): Promise<HTMLElement> {
+  vi.resetModules();
+
+  vi.doMock("@/content/profile", () => ({ profile: draftProfile }));
+  vi.doMock("@/content/experience", () => ({ experience: [] }));
+  vi.doMock("@/content/projects", () => ({ projects: [] }));
+  vi.doMock("@/content/skills", () => ({ skills: [] }));
+  vi.doMock("@/content/ai-practices", () => ({ aiPractices: [] }));
+  vi.doMock("@/content/media", () => ({ mediaAssets: [] }));
+  vi.doMock("@/content/resume", () => ({
+    resume: { id: "resume-a", isActive: false, publicationStatus: "draft" },
+  }));
+  vi.doMock("@/content/contact", () => ({ contactChannels: [], externalProfiles: [] }));
+
+  const loaded = (await import(moduleName)) as Record<string, () => React.ReactElement | null>;
+  const Section = loaded[componentName]!;
+
+  return render(<Section />).container;
+}
+
+const sections = [
+  ["Hero", "@/components/sections/hero-section", "HeroSection"],
+  ["About", "@/components/sections/about-section", "AboutSection"],
+  ["Work Experience", "@/components/sections/experience-section", "ExperienceSection"],
+  ["Selected Projects", "@/components/sections/projects-section", "ProjectsSection"],
+  ["Technical Skills", "@/components/sections/skills-section", "SkillsSection"],
+  ["AI-Assisted Engineering", "@/components/sections/ai-workflow-section", "AIWorkflowSection"],
+] as const;
+
+describe("a section with nothing publicly eligible renders nothing", () => {
+  for (const [label, moduleName, componentName] of sections) {
+    it(`${label} omits itself entirely`, async () => {
+      const container = await renderWithEmptyContent(moduleName, componentName);
+
+      expect(container).toBeEmptyDOMElement();
+    });
+  }
+
+  it("announces no heading for any omitted section", async () => {
+    for (const [label, moduleName, componentName] of sections) {
+      const container = await renderWithEmptyContent(moduleName, componentName);
+
+      // The specific failure this guards: a heading rendered outside the
+      // early return, leaving "Technical Skills" announced with nothing under
+      // it.
+      expect(container.querySelector("h1, h2, h3, h4"), label).toBeNull();
+    }
+  });
+
+  it("leaves no anchor target that scrolls to an empty region", async () => {
+    for (const [label, moduleName, componentName] of sections) {
+      const container = await renderWithEmptyContent(moduleName, componentName);
+
+      // Header links point at section ids. An id surviving an omitted section
+      // gives a keyboard user a navigation target that goes nowhere
+      // (FAC-NAV-002).
+      expect(container.querySelector("[id]"), label).toBeNull();
+    }
+  });
+});


### PR DESCRIPTION
## Purpose

Restore coverage of FAC-HOME-005 — a section with nothing publicly eligible must render **nothing at all**, not a heading with an empty body.

That was covered against real content while every section was Draft. Publishing the launch content removed the subject.

## I was wrong in the last PR

I recorded the gap with the claim that testing it *"would only assert the mock."* **That was wrong, and this file exists because of it.**

What is mocked here is the **content registry** — the raw modules under `src/content`. The real selectors run against them, and the real components run against the real selectors. Nothing about the omission decision is stubbed; the components are simply handed a repository with nothing published in it.

That is the same technique already used for the launch-indexing switch and the selector ordering tie-breaks. It exercises production code, not a stand-in.

Mocking the **selectors** would have been the version worth refusing — and the file says so, where a future reader will see it rather than in a PR description nobody re-reads.

## Three assertions per section, not one

"Renders nothing" can fail in more than one way that matters:

| Assertion | The failure it catches |
|---|---|
| Container is empty | The section renders at all |
| No `h1`–`h4` | Heading escapes the early return — "Technical Skills" announced with nothing under it |
| No element with an `id` | Anchor target survives, so a header link scrolls a keyboard user to an empty region (FAC-NAV-002) |

**Mutation-checked:** removing the omission guard from the skills section fails **all three** and leaves the other five sections green. That confirms the mocks reach the components *and* that each assertion catches a distinct failure rather than three restatements of one.

## Coverage

| | Before | After |
|---|---|---|
| `components/sections` statements | 84.90% | **96.22%** |
| `components/sections` branch | 60.00% | **70.00%** |
| All files statements | 97.14% | **98.28%** |
| All files branch | 84.86% | **86.48%** |

## Changed areas

`tests/components/homepage-section-omission.test.tsx` — new, 8 tests. **Test-only; no source file touched.**

## Tests and commands run

- `npm run check` — exit 0, **393 tests** (8 new)
- `npx playwright test` — **140 passed**, 1 skipped, three engines
- Mutation check on the skills omission guard, as above

## Known limitations

Remaining branch gaps in `components/sections` are optional-field conditionals needing content that does not exist yet — chiefly a project visual, which requires a Published media asset owned by a project. Left uncovered rather than mocked into existence; it closes naturally when project visuals land.

## Deployment impact

None. No source change.

## Rollback notes

`git revert` removes 8 tests and returns the omission path to unreachable-and-unasserted. No runtime effect.

## Confidentiality review

Pass. Fixtures are synthetic and empty.

## FAC/NFAC references

FAC-HOME-005, FAC-NAV-002, NFAC-A11Y-003, NFAC-TEST-002
