### PR TITLE
feat: publish the jury process management integration case study

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -198,20 +198,62 @@ test.describe("every public page has exactly one h1 (NFAC-A11Y-003)", () => {
   }
 });
 
-test.describe("pre-launch indexing posture", () => {
-  test("robots.txt disallows crawling while content is Draft", async ({ request }) => {
+/**
+ * Indexing posture after launch.
+ *
+ * These asserted the opposite for the whole of development: robots.txt
+ * disallowed everything and every page carried noindex, because a half-built
+ * portfolio being indexed and cached is worse for the product goal than not
+ * being found at all.
+ *
+ * The switch is derived from content — a Published profile and at least two
+ * Published projects (DEC-030) — so it flipped on its own when the second case
+ * study was published. Nobody had to remember to enable indexing, and nobody
+ * could enable it early by hand. These now assert the other side of that
+ * switch, end to end against a production build.
+ */
+test.describe("post-launch indexing posture", () => {
+  test("robots.txt allows crawling", async ({ request }) => {
     const body = await (await request.get("/robots.txt")).text();
 
-    expect(body).toMatch(/Disallow:\s*\/\s*$/m);
+    expect(body).toMatch(/Allow:\s*\/\s*$/m);
+    expect(body).not.toMatch(/Disallow:\s*\/\s*$/m);
   });
 
-  test("pages carry noindex, because robots.txt alone does not prevent indexing", async ({
-    page,
-  }) => {
+  test("robots.txt advertises the sitemap", async ({ request }) => {
+    const body = await (await request.get("/robots.txt")).text();
+
+    expect(body).toMatch(/Sitemap:\s*https?:\/\/\S+\/sitemap\.xml/i);
+  });
+
+  test("pages no longer carry noindex", async ({ page }) => {
     await page.goto("/");
 
     const robots = await page.locator('meta[name="robots"]').getAttribute("content");
 
-    expect(robots).toContain("noindex");
+    // Absent is fine — the default is indexable. Present but saying noindex is
+    // not, and would silently undo the launch.
+    expect(robots ?? "").not.toContain("noindex");
+  });
+
+  test("no public page carries noindex", async ({ page }) => {
+    for (const route of ["/", "/projects", "/projects/personal-developer-portfolio"]) {
+      await page.goto(route);
+
+      const robots = await page.locator('meta[name="robots"]').getAttribute("content");
+
+      // robots.txt asks a crawler not to fetch; the meta directive is what
+      // keeps a page out of the index. One route still carrying it would drop
+      // that page from results while the rest of the site was discoverable.
+      expect(robots ?? "", route).not.toContain("noindex");
+    }
+  });
+
+  test("a canonical url is declared for the homepage (NFAC-SEO-003)", async ({ page }) => {
+    await page.goto("/");
+
+    const canonical = await page.locator('link[rel="canonical"]').getAttribute("href");
+
+    expect(canonical).toMatch(/^https?:\/\//);
   });
 });

--- a/src/content/projects/jury-process-management.ts
+++ b/src/content/projects/jury-process-management.ts
@@ -1,18 +1,17 @@
 import { defineProject } from "@/domain/content/define";
 
 /**
- * Jury Process Management Integration — DRAFT.
+ * Jury Process Management Integration — PUBLISHED.
  *
- * A confirmed launch case study (Handoff section 4) describing professional
- * work performed under an employer.
+ * Professional work performed under an employer. Written and approved by Randi
+ * on 2026-08-09; every claim is his own.
  *
  * CONFIDENTIALITY — this is the strictest file in the repository.
  *
- * The repository is public. Draft status hides content from the website but
- * does NOT make it private on GitHub, so everything written here must already
- * be safe to read directly (ADR-011, Handoff section 7.6).
- *
- * The following must never appear in this file:
+ * The repository is public. Publication status controls what the website
+ * renders, not what GitHub serves, so everything here must be safe to read
+ * directly (ADR-011, Handoff section 7.6). The systems are described by what
+ * kind of thing they are rather than by name. The following must never appear:
  *   - internal project, module, or ticket identifiers
  *   - internal or partner system names
  *   - internal URLs or private repository links
@@ -20,105 +19,223 @@ import { defineProject } from "@/domain/content/define";
  *   - confidential architecture detail or proprietary source
  *   - screenshots that were not sanitized and approved
  *
- * confidentialityClass is "sanitized": publishable only after Randi's
- * documented confidentiality review (NFAC-PRIV-004, NFAC-SEC-002).
+ * Three of Randi's decisions here are worth preserving against future editing,
+ * because each one gives up something that would have read better.
  *
- * Every substantive section is a DRAFT PLACEHOLDER. Claude cannot author these
- * — they are factual claims about real professional work, and Handoff section 2
- * forbids inventing professional achievements. Randi writes them in P30.
+ * deliveryStatus is "completed", not "production". His reason: the evidence he
+ * holds covers implementation, pre-production investigation, and verification —
+ * not a documented production verification he personally performed. TD 9.5
+ * would have required a productionConfirmation object, and he declined to
+ * assert one he could not support. FAC-PROJECT-004 exists for exactly this.
+ *
+ * The asynchronous-synchronisation decision is stated at the level he can
+ * defend and no further. He explicitly refused to name a mechanism — polling,
+ * retrying, queue waits, job chaining — unless that was what he implemented.
+ * Do not "improve" that passage by adding a specific technique; the vagueness
+ * is the accuracy.
+ *
+ * technologyIds omits skill-rest-apis and skill-typescript. Both are plausible
+ * and neither is confirmed for this project, so both are left out rather than
+ * assumed. Add either only once the actual source is checked.
  */
 export const juryProcessManagement = defineProject({
   id: "project-jury-process-management",
   slug: "jury-process-management-integration",
   title: "Jury Process Management Integration",
   summary:
-    "DRAFT PLACEHOLDER: sanitized summary of a cross-application integration connecting a jury " +
-    "process management workflow with a separate internal application. Final wording pending " +
-    "Product Owner review.",
+    "Integrated a separate jury-management workflow with a primary academic administration " +
+    "platform, coordinating session data, scheduling state, and downstream workflow steps across " +
+    "application boundaries.",
 
   projectType: "professional",
-  role: "DRAFT PLACEHOLDER: exact role pending Product Owner confirmation",
-
-  // Not "production" — FAC-PROJECT-004 and FAC-PUBLISH-004 forbid claiming
-  // production without verified deployment, and TD 9.5 would additionally
-  // require an explicit productionConfirmation. Randi sets the truthful status
-  // in P30.
+  role: "Backend Developer — cross-application integration and workflow synchronization",
   deliveryStatus: "completed",
-  period: "DRAFT PLACEHOLDER: period pending",
+  period: "2026",
 
   context:
-    "DRAFT PLACEHOLDER: sanitized description of the system, its intended users, and the broader " +
-    "business context, with no internal identifiers or partner system names.",
+    "The work connected a primary academic administration platform with a separate application " +
+    "responsible for jury assignment and scheduling. The overall workflow crossed both " +
+    "applications: an evaluation session was created and published in the primary platform, jury " +
+    "members and scheduling were managed in the jury application, and the resulting state needed " +
+    "to support downstream marking workflows.\n\n" +
+    "Because the workflow crossed repository and application boundaries, a step could appear " +
+    "complete in one application while related data was still being synchronized in the " +
+    "background. The integration therefore required more than matching API fields; the lifecycle " +
+    "and timing between systems had to remain consistent.",
 
   problem:
-    "DRAFT PLACEHOLDER: the specific problem being solved and why it mattered, described without " +
-    "confidential detail.",
+    "The main problem was keeping workflow state synchronized across two applications without " +
+    "leaving sessions in a partially updated state. During the integration work, a background " +
+    "worker could finish before the related synchronization had fully completed, which produced " +
+    "partially synchronized jury sessions and required rework.\n\n" +
+    "Pre-production verification also exposed a missing workflow dependency around schedule " +
+    "creation. A published session needed the corresponding schedule state so the jury workflow " +
+    "could continue correctly. Separately, a lookup bug used a configurable display label as a " +
+    "data key, which failed when configuration differed from the assumption in the code.",
 
   personalResponsibilities: [
-    "DRAFT PLACEHOLDER: what Randi personally implemented, pending Product Owner confirmation.",
+    "Analyze the existing cross-application workflow and identify the states and synchronization points required between the two systems.",
+    "Implement and adjust backend integration behavior for jury-session synchronization and the downstream workflow.",
+    "Investigate an asynchronous-processing issue where worker completion occurred before related background synchronization had fully completed.",
+    "Verify the end-to-end workflow in pre-production and identify the missing schedule-related dependency.",
+    "Investigate and correct a lookup issue caused by relying on a configurable display label instead of a stable identifier.",
   ],
 
   teamResponsibilities: [
-    "DRAFT PLACEHOLDER: what belonged to teammates, other services, or other teams. Required so " +
-      "team outcomes are never presented as individual work (FAC-PROJECT-003, NFAC-CONTENT-002).",
+    "Frontend implementation and UI behavior were handled by the relevant frontend developers.",
+    "QA owned formal validation of the completed workflow after development verification.",
+    "Product and functional teams defined or clarified the expected business workflow and acceptance rules.",
   ],
 
   technicalApproach:
-    "DRAFT PLACEHOLDER: high-level solution and main component boundaries, generalized so no " +
-    "proprietary architecture is disclosed.",
+    "I started from an existing integration pattern so the new workflow would stay aligned with " +
+    "established application behavior and reduce unnecessary differences. I mapped the lifecycle " +
+    "across both applications, including publication, jury-session synchronization, scheduling, " +
+    "and the downstream actions that depended on those states.\n\n" +
+    "The integration also required treating asynchronous processing carefully. A worker reporting " +
+    "completion was not automatically equivalent to the entire cross-application state being " +
+    "synchronized, so I investigated the actual timing of background work instead of relying only " +
+    "on the worker result.\n\n" +
+    "For the configuration-dependent lookup issue, I traced the data flow back to the underlying " +
+    "identifier and corrected the logic so it did not depend on a customizable display label.",
 
   workflowOrArchitecture:
-    "DRAFT PLACEHOLDER: public-safe workflow description. Any accompanying diagram must be " +
-    "sanitized, carry alternative text, remain readable on mobile, and expose no internal " +
-    "identifiers or URLs (TD 16.4).",
+    "1. The primary academic platform creates and publishes an evaluation session.\n" +
+    "2. Session data is synchronized to the jury-management application.\n" +
+    "3. Jury assignment and scheduling are managed in the jury workflow.\n" +
+    "4. The published scheduling state is synchronized back into the broader workflow.\n" +
+    "5. The primary platform continues with downstream marking-related tasks.\n\n" +
+    "Some synchronization occurs through background processing, so end-to-end completion must " +
+    "account for both the initiating worker and the related background synchronization.",
 
   challenges: [
     {
-      title: "DRAFT PLACEHOLDER: challenge title pending",
+      title: "Asynchronous synchronization",
       description:
-        "DRAFT PLACEHOLDER: a meaningful technical or delivery problem and why it mattered.",
+        "A worker could complete before related background synchronization had finished, leaving " +
+        "jury-session data only partially synchronized. This exposed an assumption that job " +
+        "completion and end-to-end workflow completion were the same thing.",
+    },
+    {
+      title: "Missing workflow dependency",
+      description:
+        "Pre-production testing showed that the expected workflow also depended on schedule " +
+        "creation at publication time. The gap was not obvious from the isolated implementation " +
+        "and only became clear when the complete cross-application flow was exercised.",
+    },
+    {
+      title: "Configuration-dependent lookup",
+      description:
+        "A configurable display label had been used as a data key. When the configured label " +
+        "differed from the assumed value, the lookup failed and the related jury information was " +
+        "not visible.",
     },
   ],
 
   decisionsAndTradeoffs: [
     {
-      decision: "DRAFT PLACEHOLDER: decision pending",
-      rationale: "DRAFT PLACEHOLDER: why this approach was chosen over the alternatives.",
-      tradeoff: "DRAFT PLACEHOLDER: what was given up.",
+      decision: "Reuse the existing integration pattern rather than introducing a different flow",
+      rationale:
+        "Staying close to established behavior reduced unnecessary implementation differences and " +
+        "regression surface.",
+      tradeoff:
+        "The reused pattern also carried assumptions about asynchronous timing, so copying the " +
+        "pattern was not enough; its completion semantics still needed to be validated.",
+    },
+    {
+      decision:
+        "Use a stable underlying identifier for data lookup instead of a configurable display label",
+      rationale:
+        "Display labels can change by configuration, while an identifier is intended to remain " +
+        "stable for application logic.",
+      tradeoff:
+        "The implementation becomes slightly more explicit because the stable identifier must be " +
+        "resolved or carried through the data flow, but it avoids behavior that changes when " +
+        "labels are customized.",
+    },
+    {
+      decision:
+        "Stop treating completion of the initiating worker as proof that the related background " +
+        "synchronization had also completed",
+      rationale:
+        "The original implementation assumed that worker completion represented end-to-end " +
+        "completion. In practice, related background processing could still be running, which " +
+        "left some jury sessions only partially synchronized.",
+      tradeoff:
+        "The workflow became more dependent on explicit synchronization state and completion " +
+        "handling instead of a simpler worker-success result. This added coordination and " +
+        "verification logic, but avoided treating partially synchronized data as complete.",
     },
   ],
 
   implementationSummary:
-    "DRAFT PLACEHOLDER: what was implemented, and explicitly what was not implemented by Randi.",
+    "I implemented and refined backend integration behavior connecting the jury-management " +
+    "workflow with the primary academic platform, covering cross-application session " +
+    "synchronization, scheduling-related workflow state, and downstream processing. I also " +
+    "investigated and corrected issues discovered during integration and environment " +
+    "verification, including asynchronous synchronization behavior and a configuration-dependent " +
+    "lookup.\n\n" +
+    "Frontend UI implementation, ownership of product and business rules, and formal QA " +
+    "validation were outside my primary scope; my work focused on the backend integration and " +
+    "synchronization behavior between the applications.",
 
   testingAndVerification:
-    "DRAFT PLACEHOLDER: automated tests where relevant, manual verification, regression checks, " +
-    "QA involvement, and deployment verification.",
+    "I verified the integration manually through the end-to-end workflow in the pre-production " +
+    "environment, including session publication, synchronization, jury scheduling, and the " +
+    "downstream workflow. Issues found during that verification were corrected before the flow " +
+    "was validated again. QA was also involved in formal validation of the feature.\n\n" +
+    "Following the workflow end to end rather than checking an isolated API response is what " +
+    "exposed the missing schedule dependency and the synchronization assumptions.",
 
   outcome:
-    "DRAFT PLACEHOLDER: the verified, observable result. No invented metrics — where exact " +
-    "numbers are unavailable, truthful outcomes are used instead (FAC-PUBLISH-005).",
+    "After the fixes, the connected applications could continue through the expected jury " +
+    "workflow without relying on the earlier synchronization and configurable-label assumptions. " +
+    "The session could move through publication, jury assignment and scheduling, and into the " +
+    "downstream marking workflow with the required state available across the integration.\n\n" +
+    "No performance or adoption metric was measured for this work, so none is claimed here.",
 
   aiUsage:
-    "DRAFT PLACEHOLDER: how AI assisted, what Randi decided, and how the output was reviewed and " +
-    "validated. Raw AI session exports are never published (FAC-AI-003).",
+    "I used AI as part of the engineering workflow for analysis and implementation support, but I " +
+    "remained responsible for validating the generated changes against the real application " +
+    "behavior. One AI-generated change relied on a configurable display label as a data key; that " +
+    "assumption failed when the label differed by configuration.\n\n" +
+    "I investigated the actual data model, corrected the lookup to rely on a stable identifier, " +
+    "and re-evaluated the surrounding flow. The incident reinforced that generated code still " +
+    "needs domain-aware review, realistic test data, and verification against configurable " +
+    "behavior.",
 
   lessonsLearned:
-    "DRAFT PLACEHOLDER: technical and process learning, limitations, and what would be done differently.",
+    "I initially reused an existing integration approach without questioning its asynchronous " +
+    "assumptions deeply enough. A worker could report completion before related background " +
+    "synchronization had finished, which led to partially synchronized sessions and rework. I " +
+    "learned to distinguish job completion from end-to-end workflow completion and to verify " +
+    "timing and state transitions across the whole integration.\n\n" +
+    "I also learned not to treat written acceptance criteria as a substitute for understanding " +
+    "the real operational flow. The missing schedule dependency became visible only when the " +
+    "workflow was exercised end to end. I would now ask more questions about implicit " +
+    "cross-system dependencies earlier, map the lifecycle before implementation, and validate " +
+    "configurable data against stable identifiers rather than display labels.",
 
-  technologyIds: ["skill-typescript", "skill-nodejs", "skill-mongodb", "skill-graphql"],
+  technologyIds: [
+    "skill-nodejs",
+    "skill-graphql",
+    "skill-mongodb",
+    "skill-git",
+    "skill-ai-assisted-engineering",
+  ],
 
   confidentialityNote:
-    "This case study uses a sanitized project name and generalized workflow descriptions. " +
-    "Private source code, internal URLs, internal identifiers, and company-sensitive information " +
-    "are intentionally excluded.",
+    "This case study uses generalized system names and workflow descriptions. Private source " +
+    "code, internal identifiers, URLs, environment details, and company-sensitive data are " +
+    "intentionally excluded.",
 
   confidentialityClass: "sanitized",
 
-  // See the note in personal-developer-portfolio.ts: featured stays false
-  // until this is Published (Technical Design 9.4).
-  featured: false,
+  // Featured second, behind the existing priority 1. Two Published projects
+  // render two balanced cards on the homepage (FAC-HOME-004), and TD 9.4
+  // requires a featured project to be Published — both now hold.
+  featured: true,
   featuredPriority: 2,
-  publicationStatus: "draft",
-  updatedAt: "2026-08-04",
+  publicationStatus: "published",
+  updatedAt: "2026-08-09",
 });

--- a/tests/components/homepage-empty-state.test.tsx
+++ b/tests/components/homepage-empty-state.test.tsx
@@ -98,37 +98,43 @@ describe("Work Experience presents the real employment history", () => {
   });
 });
 
-/**
- * Selected Projects is the one section with eligible content: the Personal
- * Developer Portfolio case study is Published and featured.
- */
-describe("Selected Projects renders the one published project", () => {
-  it("renders exactly one card", () => {
+describe("Selected Projects renders both launch case studies", () => {
+  it("renders two cards (FAC-HOME-004)", () => {
     render(<ProjectsSection />);
 
-    expect(screen.getAllByRole("article")).toHaveLength(1);
+    expect(screen.getAllByRole("article")).toHaveLength(2);
   });
 
-  it("renders the published case study and links to it", () => {
+  it("links each card to its case study", () => {
     render(<ProjectsSection />);
 
     expect(screen.getByRole("link", { name: "Personal Developer Portfolio" })).toHaveAttribute(
       "href",
       "/projects/personal-developer-portfolio",
     );
+    expect(
+      screen.getByRole("link", { name: "Jury Process Management Integration" }),
+    ).toHaveAttribute("href", "/projects/jury-process-management-integration");
   });
 
-  it("does not render the Draft professional case study", () => {
-    render(<ProjectsSection />);
-
-    expect(screen.queryByText(/Jury Process Management/i)).not.toBeInTheDocument();
-  });
-
-  it("pads nothing — one project means one card, no filler (FAC-HOME-004)", () => {
+  it("pads nothing — two projects means two cards, no filler (FAC-HOME-004)", () => {
     const { container } = render(<ProjectsSection />);
 
     expect(container.textContent).not.toMatch(/coming soon/i);
-    expect(screen.getAllByRole("article")).toHaveLength(1);
+    expect(screen.getAllByRole("article")).toHaveLength(2);
+  });
+
+  /**
+   * FAC-PROJECT-004. "Completed" is displayed for the professional work
+   * because the evidence does not support a production claim. A card that
+   * silently upgraded that label would misrepresent the work on the first
+   * screen a recruiter sees.
+   */
+  it("shows the honest delivery status on the professional card", () => {
+    const { container } = render(<ProjectsSection />);
+
+    expect(container.textContent).toContain("Completed");
+    expect(container.textContent).not.toMatch(/\bProduction\b/);
   });
 });
 

--- a/tests/content/modules.test.ts
+++ b/tests/content/modules.test.ts
@@ -129,22 +129,46 @@ describe("confidentiality invariants for a public repository", () => {
   });
 });
 
-describe("draft state before content finalization", () => {
-  it("publishes only the case study written from verifiable facts", () => {
-    // The Personal Developer Portfolio case study describes this repository,
-    // so every claim in it is checkable against the code and the deployment.
+describe("content state at launch", () => {
+  it("publishes both launch case studies", () => {
     const published = projects.filter((project) => project.publicationStatus === "published");
 
-    expect(published.map((project) => project.slug)).toEqual(["personal-developer-portfolio"]);
+    expect(published.map((project) => project.slug).sort()).toEqual([
+      "jury-process-management-integration",
+      "personal-developer-portfolio",
+    ]);
   });
 
-  it("keeps the professional case study Draft until Randi writes it", () => {
-    // This one describes work under an employer and is still placeholder text.
-    // Publishing it before Randi authors and reviews it would put unreviewed
-    // claims about a former workplace on a public site.
+  /**
+   * The professional case study describes work under an employer, published on
+   * a public site with a public repository. These assert the properties that
+   * make that safe, rather than assuming the review that approved it will be
+   * repeated on every future edit.
+   */
+  it("keeps the professional case study sanitized and claim-free", () => {
     const jury = projects.find((project) => project.slug === "jury-process-management-integration");
 
-    expect(jury?.publicationStatus).toBe("draft");
+    expect(jury?.confidentialityClass).toBe("sanitized");
+    expect(jury?.confidentialityNote).toBeTruthy();
+
+    // FAC-PROJECT-003: team work is stated separately, so nothing shared is
+    // read as solely his.
+    expect(jury?.teamResponsibilities?.length).toBeGreaterThan(0);
+
+    // FAC-PROJECT-004: "production" would require verified confirmation, and
+    // the evidence for this work does not support that claim.
+    expect(jury?.deliveryStatus).not.toBe("production");
+    expect(jury?.productionConfirmation).toBeUndefined();
+  });
+
+  it("claims no invented metric in the professional case study", () => {
+    const jury = projects.find((project) => project.slug === "jury-process-management-integration");
+    const prose = `${jury?.outcome} ${jury?.implementationSummary} ${jury?.testingAndVerification}`;
+
+    // No percentage, and no "Nx" multiplier. A measured number would be fine;
+    // none was measured, so none may appear.
+    expect(prose).not.toMatch(/\d+\s*%/);
+    expect(prose).not.toMatch(/\b\d+x\b/i);
   });
 
   it("publishes the profile now that Randi has written the headline and summary", () => {
@@ -164,10 +188,11 @@ describe("draft state before content finalization", () => {
     }
   });
 
-  it("does not yet satisfy the launch rule of two Published projects", () => {
-    // Asserted deliberately: this is why release validation must fail today.
+  it("satisfies the launch rule of at least two Published projects", () => {
+    // This assertion was inverted for the whole of development. It is why
+    // release validation failed, and flipping it is what let the site launch.
     const published = projects.filter((project) => project.publicationStatus === "published");
 
-    expect(published.length).toBeLessThan(2);
+    expect(published.length).toBeGreaterThanOrEqual(2);
   });
 });

--- a/tests/content/release-validation.test.ts
+++ b/tests/content/release-validation.test.ts
@@ -110,23 +110,51 @@ function releaseReadyContent(): ContentSet {
 }
 
 /**
- * The central assertion of this phase.
+ * Release validation against the real content set.
  *
- * Release validation is the only thing standing between Draft placeholders and
- * a recruiter. If it ever passes on the current content, the safety property
- * that makes Draft-based development acceptable has been lost.
+ * For the whole of development this block asserted that the gate *failed* —
+ * that was the safety property making Draft-based development acceptable. On
+ * 2026-08-09 the launch content was completed and the gate passed for the
+ * first time.
+ *
+ * The rules did not stop mattering; their subject changed. Each is now
+ * asserted in both directions: it fires against a content set that violates
+ * it, and it does not fire against real content. Asserting only the second
+ * would leave a broken rule and a satisfied rule looking identical, which is
+ * exactly how a gate quietly stops being a gate.
  */
-describe("release validation refuses the current Draft content", () => {
-  it("fails", () => {
-    expect(validateRelease(draftContent(), { siteUrl: SITE_URL }).length).toBeGreaterThan(0);
+describe("release validation accepts the real content set", () => {
+  it("passes", () => {
+    expect(validateRelease(draftContent(), { siteUrl: SITE_URL })).toEqual([]);
   });
 
-  it("reports that fewer than two projects are Published (FAC-HOME-004)", () => {
-    expect(rulesFor(draftContent())).toContain("minimum-published-projects");
+  it("reports fewer than two Published projects (FAC-HOME-004)", () => {
+    const base = draftContent();
+    const [first] = base.projects;
+
+    expect(rulesFor({ ...base, projects: [first!] })).toContain("minimum-published-projects");
+    expect(rulesFor(base)).not.toContain("minimum-published-projects");
   });
 
-  it("reports both required launch case studies as unpublished", () => {
-    expect(rulesFor(draftContent())).toContain("required-launch-projects");
+  it("reports a required launch case study that is not publicly eligible", () => {
+    const base = draftContent();
+    const [first, second] = base.projects;
+
+    // Draft is one way to fail this; a Restricted classification is the other,
+    // and it is the one that would actually leak if the rule broke.
+    expect(
+      rulesFor({
+        ...base,
+        projects: [first!, { ...second!, publicationStatus: "draft" as const }],
+      }),
+    ).toContain("required-launch-projects");
+    expect(
+      rulesFor({
+        ...base,
+        projects: [first!, { ...second!, confidentialityClass: "restricted" as const }],
+      }),
+    ).toContain("required-launch-projects");
+    expect(rulesFor(base)).not.toContain("required-launch-projects");
   });
 
   /**

--- a/tests/content/selectors-real-content.test.ts
+++ b/tests/content/selectors-real-content.test.ts
@@ -17,61 +17,93 @@ import {
 /**
  * Selectors against the real, unmocked content modules.
  *
- * These assert what the live site actually exposes right now. They are meant
- * to fail whenever publication state changes, so that going from "not public"
- * to "public" is always a reviewed diff rather than something that happens
- * quietly.
+ * These assert what the live site actually exposes. They are written to fail
+ * whenever publication state changes, so going from "not public" to "public"
+ * is always a reviewed diff rather than something that happens quietly. Every
+ * content record has now made that transition, and each one broke these tests
+ * on the way through — which was the point.
  *
- * Current state: the Personal Developer Portfolio case study is Published.
- * Everything else remains Draft pending Randi's content.
+ * Current state: launch-ready. Both case studies, the profile, all three roles,
+ * skills, AI practices, and the resume are Published. isPubliclyLaunchReady()
+ * returns true, so indexing is enabled.
  */
-describe("exactly one project is public", () => {
-  it("exposes the Personal Developer Portfolio case study", () => {
-    const slugs = getPublishedProjects().map((project) => project.slug);
-
-    expect(slugs).toEqual(["personal-developer-portfolio"]);
-  });
-
-  it("features it on the homepage", () => {
-    expect(getFeaturedProjects().map((project) => project.slug)).toEqual([
+describe("both launch case studies are public", () => {
+  it("exposes them in the approved order", () => {
+    // featuredPriority decides: the portfolio case study is 1, the
+    // professional one 2 (FAC-PROJECTS-003).
+    expect(getPublishedProjects().map((project) => project.slug)).toEqual([
       "personal-developer-portfolio",
+      "jury-process-management-integration",
     ]);
   });
 
-  it("resolves its slug", () => {
+  it("features both, so the homepage renders two balanced cards (FAC-HOME-004)", () => {
+    expect(getFeaturedProjects().map((project) => project.slug)).toEqual([
+      "personal-developer-portfolio",
+      "jury-process-management-integration",
+    ]);
+  });
+
+  it("resolves both slugs", () => {
     expect(getPublishedProjectBySlug("personal-developer-portfolio")?.title).toBe(
       "Personal Developer Portfolio",
     );
+    expect(getPublishedProjectBySlug("jury-process-management-integration")?.title).toBe(
+      "Jury Process Management Integration",
+    );
   });
 
-  it("offers no adjacent neighbours while it is the only public project", () => {
-    const { previous, next } = getAdjacentPublishedProjects("personal-developer-portfolio");
+  /**
+   * Adjacency has a real subject for the first time. Until now one project was
+   * public, so both neighbours were null and the code path was never taken.
+   */
+  it("links each case study to the other, and nowhere else", () => {
+    const first = getAdjacentPublishedProjects("personal-developer-portfolio");
+    const second = getAdjacentPublishedProjects("jury-process-management-integration");
 
-    // Critically, `next` must not be the Draft professional case study.
-    expect(previous).toBeNull();
-    expect(next).toBeNull();
+    expect(first.previous).toBeNull();
+    expect(first.next?.slug).toBe("jury-process-management-integration");
+
+    expect(second.previous?.slug).toBe("personal-developer-portfolio");
+    expect(second.next).toBeNull();
+  });
+
+  it("resolves an unknown slug to null", () => {
+    expect(getPublishedProjectBySlug("no-such-project-exists")).toBeNull();
   });
 });
 
 /**
- * The confidentiality-critical assertion in this file.
+ * The professional case study is public now, so the guarantee it needs has
+ * changed from "must be invisible" to "must be safe to see".
  *
- * The Jury Process Management case study describes professional work and is
- * still Draft placeholder text. It must stay invisible until Randi has written
- * and reviewed it. If this ever passes, unreviewed content about an employer
- * has reached the public site.
+ * These are the properties that made publishing it acceptable, asserted at the
+ * selector layer so a later content edit cannot quietly drop one.
  */
-describe("the professional case study remains invisible", () => {
-  it("does not appear in the published project list", () => {
-    const slugs = getPublishedProjects().map((project) => project.slug);
+describe("the professional case study is published safely", () => {
+  const jury = () => getPublishedProjectBySlug("jury-process-management-integration");
 
-    expect(slugs).not.toContain("jury-process-management-integration");
+  it("is classified sanitized and carries its confidentiality note", () => {
+    expect(jury()?.confidentialityClass).toBe("sanitized");
+    expect(jury()?.confidentialityNote).toBeTruthy();
   });
 
-  it("resolves to null, identically to an unknown slug", () => {
-    expect(getPublishedProjectBySlug("jury-process-management-integration")).toBe(
-      getPublishedProjectBySlug("no-such-project-exists"),
-    );
+  it("separates team work from Randi's own (FAC-PROJECT-003)", () => {
+    expect(jury()?.personalResponsibilities.length).toBeGreaterThan(0);
+    expect(jury()?.teamResponsibilities?.length).toBeGreaterThan(0);
+  });
+
+  it("does not claim production without verified confirmation (FAC-PROJECT-004)", () => {
+    expect(jury()?.deliveryStatus).toBe("completed");
+    expect(jury()?.productionConfirmation).toBeUndefined();
+  });
+
+  it("names no internal identifier, system, or URL (NFAC-SEC-002)", () => {
+    const record = JSON.stringify(jury());
+
+    expect(record).not.toMatch(/\b[A-Z]{2,}_\d/);
+    expect(record).not.toMatch(/https?:\/\/(localhost|127\.0\.0\.1|10\.|192\.168\.)/);
+    expect(record).not.toMatch(/\.internal\b|\bintranet\b|\bvpn\./i);
   });
 });
 
@@ -88,10 +120,10 @@ describe("the professional identity is public", () => {
     expect(`${published?.headline} ${published?.summary}`).not.toMatch(/DRAFT\s+PLACEHOLDER/);
   });
 
-  it("still reports not launch-ready, because one project is not two (DEC-030)", () => {
-    // Publishing the profile satisfies half of the launch rule. Asserting the
-    // half that is still unmet is what keeps indexing disabled honestly.
-    expect(isPubliclyLaunchReady()).toBe(false);
+  it("contributes half of the launch rule (DEC-030)", () => {
+    // A Published profile is one of the two conditions. The other is two
+    // Published projects, asserted in its own block below.
+    expect(getPublishedProfile()).not.toBeNull();
   });
 });
 
@@ -160,11 +192,19 @@ describe("skills and AI practices are public", () => {
   });
 });
 
-describe("the site is not yet launch-ready, so indexing stays disabled", () => {
-  it("reports not launch-ready with only one published project", () => {
-    // DEC-030 requires a Published profile and at least two Published
-    // projects. Until both hold, robots.txt disallows and pages carry noindex.
-    expect(isPubliclyLaunchReady()).toBe(false);
+describe("the site is launch-ready, so indexing is enabled", () => {
+  /**
+   * The switch that lifts noindex and lets robots.txt allow crawling. It is
+   * derived from content rather than set by hand, so nobody had to remember to
+   * enable indexing at launch and nobody could enable it early.
+   *
+   * Both halves of DEC-030 are asserted, because either one silently breaking
+   * would leave the site either invisible or indexed while incomplete.
+   */
+  it("reports launch-ready with a Published profile and two Published projects", () => {
+    expect(getPublishedProfile()).not.toBeNull();
+    expect(getPublishedProjects().length).toBeGreaterThanOrEqual(2);
+    expect(isPubliclyLaunchReady()).toBe(true);
   });
 });
 

--- a/tests/domain/launch-readiness.test.ts
+++ b/tests/domain/launch-readiness.test.ts
@@ -64,7 +64,7 @@ describe("isPubliclyLaunchReady", () => {
     expect(isPubliclyLaunchReady()).toBe(true);
   });
 
-  it("is false for the real content set today", async () => {
+  it("is true for the real content set", async () => {
     // doMock registrations survive resetModules, so the mocks from the tests
     // above must be explicitly removed or this reads mocked content and
     // silently passes for the wrong reason.
@@ -74,8 +74,9 @@ describe("isPubliclyLaunchReady", () => {
 
     const { isPubliclyLaunchReady } = await import("@/domain/content/selectors");
 
-    // Everything is Draft, so the site must not be indexable. This flips on its
-    // own at P30 — deliberately, so nobody has to remember to enable indexing.
-    expect(isPubliclyLaunchReady()).toBe(false);
+    // Flipped on 2026-08-09 when the second case study was published. It
+    // flipped on its own — deliberately, so nobody had to remember to enable
+    // indexing, and so nobody could enable it early by hand.
+    expect(isPubliclyLaunchReady()).toBe(true);
   });
 });


### PR DESCRIPTION
## Purpose

The second launch case study. **`npm run release:check` now exits 0 — every gate, end to end, for the first time in this project's history.**

That gate failed for the entire build. Its failing was the mechanism that made developing against placeholders safe. `isPubliclyLaunchReady()` is now true, so `noindex` lifts and robots.txt allows crawling — **derived from content, so it flipped on its own.**

## Three refusals worth preserving

Randi gave up something readable in each of these. The file records why, so a later edit does not quietly reverse them.

**`deliveryStatus: "completed"`, not `"production"`.** His evidence covers implementation, pre-production investigation, and verification — not a production verification he personally performed. TD 9.5 would have required a `productionConfirmation`, and he declined to assert one he could not support. FAC-PROJECT-004 exists for exactly this case.

**The async decision names no mechanism.** He explicitly refused to say polling, retrying, queue waits, or job chaining unless that was what he implemented — and I have no access to that source to check. **The vagueness is the accuracy**, and the file says so to stop a future editor "improving" it.

**`technologyIds` omits `skill-rest-apis` and `skill-typescript`.** Both plausible, neither confirmed. Left out rather than assumed.

The outcome section claims no metric, because none was measured.

## Seventeen brittle assertions caught the transition

The release-validation block is the significant one. For the whole build it asserted the gate **failed**. Each rule is now asserted **in both directions** — it fires against content that violates it, and stays silent against real content.

Asserting only the second would leave a broken rule and a satisfied rule looking identical. That is precisely how a gate stops being a gate without anyone noticing.

**Adjacent-project navigation has a real subject for the first time.** With one public project both neighbours were always null and the code path had never run. Each case study now links to the other and nowhere else.

**The e2e indexing tests were inverted, not deleted** — robots.txt now allows and advertises the sitemap, and no public page carries `noindex`.

## New assertions guarding the professional record

Published employer work needs different protection than hidden work. These pin what made publishing it acceptable:

- Classified `sanitized`, confidentiality note present
- `teamResponsibilities` non-empty — FAC-PROJECT-003, so shared work is never read as solely his
- `deliveryStatus` is not `production` and no `productionConfirmation` exists
- No internal identifier pattern, internal URL, or private-network host anywhere in the record
- No percentage or `Nx` multiplier in the prose — no metric was measured, so none may appear

## Tests and commands run

- `npm run release:check` — **exit 0**
- 397 unit tests · **149 e2e** across Chromium, Firefox, WebKit
- `validate:release` — passes
- `check:links` — no broken link
- `audit:prod` — 0 vulnerabilities
- Build emits both project routes

## Known limitations

`check:links` reported `github.com` broken during an earlier run. That was a local network outage — `curl` could not reach it either, and it resolves `ok` now. The script treats an unmakeable request as broken **by design**; the behaviour is correct and was left alone.

LinkedIn and the email address still report `manual` — an automated request cannot settle either. Confirm both by hand at release-checklist step 5.

## Deployment impact

**Significant.** The site becomes indexable: `noindex` lifts, robots.txt allows crawling and advertises the sitemap, and `/projects/jury-process-management-integration` is generated. The homepage renders two project cards.

## Rollback notes

`git revert` returns the case study to Draft, which drops the site back below the launch threshold and re-enables `noindex` automatically. Note that reverting does **not** un-index anything already crawled.

## Confidentiality review

Pass — and this is the file that most needed it. Systems are described by what kind of thing they are, never by name. No internal identifier, partner system, URL, environment detail, or customer data. Asserted by test, not only by review.

## FAC/NFAC references

FAC-PROJECT-001 through 008, FAC-HOME-004, FAC-PROJECTS-003, DEC-030, NFAC-SEO-001/002/003, NFAC-SEC-002, NFAC-PRIV-004, NFAC-CONTENT-002/004
