### PR TITLE
docs: record P31 production verification of the launched site

### DIFF
--- a/docs/release-audit.md
+++ b/docs/release-audit.md
@@ -152,3 +152,103 @@ from release validation.
 
 Re-run this audit at P31 against the launched site, when SEO becomes meaningful
 and the photograph makes performance worth re-measuring.
+
+---
+
+## 2026-08-09 — P31 production verification, post-launch
+
+| | |
+|---|---|
+| Commit audited | `847deda` on `production` |
+| Deployment | `https://developer-portfolio-delta-three.vercel.app` |
+| Content state | **Launch complete.** Profile, three Work Experience records, both case studies, twelve skills, four AI practices, and the active Resume all Published |
+| Purpose | Verify the launched site rather than infer it from a green deployment (NFAC-CICD-004) |
+
+### The gate that had never passed
+
+```text
+npm run release:check → exit 0
+```
+
+`release:check` failed for the entire build, and that failing was the mechanism
+that made developing against placeholder content acceptable (ADR-006). This is
+the first time every stage has passed end to end.
+
+| Stage | Result |
+|---|---|
+| `format:check`, `lint`, `typecheck` | pass |
+| `validate:content` | pass |
+| `test:run` | pass, 397 tests |
+| `build` | pass, both project routes emitted |
+| `validate:release` | **pass — first time** |
+| `check:links` | pass, no broken link |
+| `test:e2e` | pass, 149 tests on three engines |
+| `audit:prod` | pass, 0 vulnerabilities |
+
+### Indexing reversed itself, as designed
+
+`isPubliclyLaunchReady()` is derived from content — a Published profile and at
+least two Published projects (DEC-030). Publishing the second case study
+flipped it with no configuration change, which is what the design was for:
+nobody had to remember to enable indexing at launch, and nobody could enable it
+early by hand.
+
+Verified live:
+
+| | Before launch | After |
+|---|---|---|
+| `robots` meta | `noindex, nofollow, nocache` | `index, follow` |
+| `robots.txt` | `Disallow: /` | `Allow: /` plus a `Sitemap:` line |
+| Sitemap entries | 3 | 4 — both case studies present |
+
+### Lighthouse, launched site
+
+| Page | Performance | Accessibility | Best Practices | SEO |
+|---|---|---|---|---|
+| Home | 97 | 100 | 100 | **100** |
+| Projects Index | 98 | 100 | 100 | **100** |
+| Project Detail (professional) | 97 | 100 | 100 | **100** |
+
+Core Web Vitals, Home: LCP **1.6 s**, CLS **0.005**, TBT **180 ms** — inside
+NFAC-PERF-001. No failing SEO audit.
+
+**A prediction that did not hold.** Implementation plan risk R-04 anticipated
+that a large hero photograph would threaten the ≥ 90 Lighthouse requirement,
+and a reading taken immediately after the photograph deployed showed
+performance 92 and LCP 2.5 s, exactly at the threshold. That was recorded as
+having no headroom left.
+
+Re-measured on a warm deployment the same page scores 97 with LCP 1.6 s. The
+earlier figure was a cold-deployment artefact, not a content cost. The useful
+correction is about method rather than about the photograph: **a single
+measurement taken immediately after a deploy is not a baseline**, and treating
+one as such produced a risk assessment that was wrong in the pessimistic
+direction.
+
+### Production smoke checks (TD 24.5)
+
+| Check | Result |
+|---|---|
+| `/`, `/projects`, both case studies, `/resume.pdf` | all 200 |
+| `/resume.pdf` content type | `application/pdf` |
+| Open Graph title, url, image, type | present; image 200 `image/png` |
+| GitHub profile link | 200 |
+| LinkedIn profile link | 999 — anti-bot challenge, **requires manual confirmation** |
+| Unknown route | 404, and no word suggesting hidden content exists (DEC-047) |
+| Security headers | `X-Content-Type-Options`, `X-Frame-Options`, `Referrer-Policy` all present |
+| Draft markers in rendered HTML | 0 |
+
+### Still outstanding after launch
+
+| Item | Owner | Note |
+|---|---|---|
+| Manual confirmation of the LinkedIn and email actions | Randi | No automated request can settle either; release-checklist step 5 |
+| Repository visibility switch to Public | Randi | The repository is **still private**. The live site is public; its source is not |
+| `Protect production` ruleset, secret scanning, push protection, code scanning | Randi | All 403 on GitHub Free while private. They unlock the moment visibility changes, and `github-configuration.md` section 9 requires enabling them **first**, before the URL is sent anywhere |
+| P32 rollback drill | Randi | Vercel rollback is interface-only |
+| P33 Docker portability | Post-launch | Cannot be verified in the current environment; Docker is not installed |
+
+The gap worth naming: the site is launched and indexable while the repository
+that produces it has no enforced branch protection. Nothing prevents a direct
+push to `production` today. That has been true for the whole build and was
+acceptable while the site was invisible; it is less acceptable now.


### PR DESCRIPTION
## Purpose

**P31.** NFAC-CICD-004 requires production to be *verified*, not inferred from a green deployment. This records what was actually checked against the live site after launch.

## The gate that had never passed

```
npm run release:check → exit 0
```

It failed for the entire build — that failing was the mechanism that made developing against placeholders acceptable (ADR-006). Every stage now passes end to end: 397 unit tests, 149 e2e on three engines, release validation, link check, 0 vulnerabilities, both routes emitted.

## Indexing reversed itself, with no configuration change

`isPubliclyLaunchReady()` is derived from content — a Published profile and two Published projects (DEC-030). Publishing the second case study flipped it:

| | Before | After |
|---|---|---|
| `robots` meta | `noindex, nofollow, nocache` | `index, follow` |
| `robots.txt` | `Disallow: /` | `Allow: /` + `Sitemap:` |
| Sitemap entries | 3 | 4 |

That was the whole point of deriving it. Nobody had to remember to enable indexing at launch, and nobody could enable it early by hand.

## Lighthouse, launched

| Page | Perf | A11y | Best | SEO |
|---|---|---|---|---|
| Home | 97 | 100 | 100 | **100** |
| Projects Index | 98 | 100 | 100 | **100** |
| Project Detail | 97 | 100 | 100 | **100** |

LCP **1.6 s** · CLS **0.005** · TBT 180 ms. No failing SEO audit — the `noindex` that held SEO at 66 has lifted.

## A prediction I recorded that did not hold

Plan risk **R-04** anticipated the hero photograph threatening the ≥ 90 requirement. A reading taken immediately after the photograph deployed showed **92, LCP 2.5 s** — exactly at the threshold. I recorded that as having no headroom, and warned you about it more than once.

Re-measured on a warm deployment: **97, LCP 1.6 s.**

The earlier figure was a cold-deployment artefact, not a content cost. The correction worth keeping is about method: **a single measurement taken right after a deploy is not a baseline.** Treating one as such produced a risk assessment that was wrong in the pessimistic direction.

## Production smoke checks (TD 24.5)

All routes 200 · `/resume.pdf` serves `application/pdf` · Open Graph complete with a 200 `image/png` · GitHub link 200 · unknown route 404 with **no word suggesting hidden content exists** (DEC-047) · all three security headers present · **0** draft markers in rendered HTML.

## The gap launch created rather than closed

The document names it plainly: **the site is public and indexable while the repository producing it has no enforced branch protection.** Rulesets are still 403 on GitHub Free for a private repo. Nothing prevents a direct push to `production` today.

That was acceptable while the site was invisible. It is less acceptable now.

## Still outstanding, all yours

- Manual confirmation of the **LinkedIn** (returns 999 to any automated request) and **email** actions
- **Repository visibility switch** → unlocks `Protect production`, secret scanning, push protection, code scanning. [github-configuration.md §9](docs/governance/github-configuration.md) requires enabling these **first**, before the URL goes anywhere
- **P32 rollback drill** — Vercel rollback is interface-only
- **P33 Docker** — cannot be verified here; Docker is not installed

## Changed areas

`docs/release-audit.md` — appended a second dated entry. **Documentation only.**

## Tests and commands run

`npm run check` — exit 0, 397 tests. All figures above were measured against the live deployment, not inferred.

## Deployment impact

None. Documentation only.

## Rollback notes

`git revert` removes the record. No runtime effect.

## Confidentiality review

Pass. Public URLs, Lighthouse scores, and HTTP status codes only.

## FAC/NFAC references

FAC-OWNER-005, NFAC-REL-001, NFAC-CICD-004, NFAC-TEST-004, NFAC-PERF-001, NFAC-PERF-002, NFAC-SEO-001–004, DEC-030, DEC-047
