### PR TITLE
fix: stop the section omission tests failing under CPU load

### DIFF
--- a/tests/components/homepage-section-omission.test.tsx
+++ b/tests/components/homepage-section-omission.test.tsx
@@ -66,34 +66,38 @@ const sections = [
   ["AI-Assisted Engineering", "@/components/sections/ai-workflow-section", "AIWorkflowSection"],
 ] as const;
 
+/**
+ * One test per section, asserting all three properties from a single render.
+ *
+ * The shape matters. This started as three tests that each looped over all six
+ * sections, which meant two of them performed six full module-graph reloads
+ * inside one five-second budget. Each reload resets the module registry and
+ * re-imports a component, its selectors, and the content modules beneath them.
+ *
+ * That passed in isolation and failed intermittently in the full suite — once
+ * at 11.3 seconds, while a CodeQL scan competed for CPU. A test that fails only
+ * under load is worse than one that fails outright: it trains you to re-run
+ * rather than to read.
+ *
+ * Now no test performs more than one reload, so none is near the timeout, and
+ * the file does six reloads in total rather than eighteen. Each assertion
+ * carries its own message, so a failure still names which property broke.
+ */
 describe("a section with nothing publicly eligible renders nothing", () => {
   for (const [label, moduleName, componentName] of sections) {
     it(`${label} omits itself entirely`, async () => {
       const container = await renderWithEmptyContent(moduleName, componentName);
 
-      expect(container).toBeEmptyDOMElement();
-    });
-  }
+      expect(container, `${label}: rendered something`).toBeEmptyDOMElement();
 
-  it("announces no heading for any omitted section", async () => {
-    for (const [label, moduleName, componentName] of sections) {
-      const container = await renderWithEmptyContent(moduleName, componentName);
-
-      // The specific failure this guards: a heading rendered outside the
-      // early return, leaving "Technical Skills" announced with nothing under
-      // it.
-      expect(container.querySelector("h1, h2, h3, h4"), label).toBeNull();
-    }
-  });
-
-  it("leaves no anchor target that scrolls to an empty region", async () => {
-    for (const [label, moduleName, componentName] of sections) {
-      const container = await renderWithEmptyContent(moduleName, componentName);
+      // A heading rendered outside the early return would leave "Technical
+      // Skills" announced with nothing under it (FAC-HOME-005).
+      expect(container.querySelector("h1, h2, h3, h4"), `${label}: kept a heading`).toBeNull();
 
       // Header links point at section ids. An id surviving an omitted section
       // gives a keyboard user a navigation target that goes nowhere
       // (FAC-NAV-002).
-      expect(container.querySelector("[id]"), label).toBeNull();
-    }
-  });
+      expect(container.querySelector("[id]"), `${label}: kept an anchor target`).toBeNull();
+    });
+  }
 });


### PR DESCRIPTION
## Purpose

The homepage section omission tests **failed once during a full-suite run** and passed every time the file ran alone.

That pattern is the interesting part. A test that only fails under load is worse than one that fails outright — it trains you to re-run rather than to read.

## The cause was the test shape, not the source

The failing run took **11.3 s** against Vitest's **5 s** default, while a CodeQL scan competed for CPU.

Two of the three tests looped over all six sections **inside a single test**, so each performed six full module-graph reloads within one budget. Every reload resets the module registry and re-imports a component, its selectors, and the content modules beneath them.

The third test did one reload per test and **never flaked** — which is what pointed at the cause.

## The fix

One test per section, asserting all three properties from a single render. No test does more than one reload.

| | Before | After |
|---|---|---|
| Reloads in one test | 6 | **1** |
| Reloads in the file | 18 | **6** |
| File duration | ~11 s | **3.6 s** |

## Coverage is unchanged, and still precise

Each assertion carries its own message. Verified by removing the skills omission guard — fails with `Technical Skills: rendered something` and leaves the other five sections green.

## Why not just raise the timeout

It would also have stopped the failure. It was the wrong fix: the work genuinely did not need to be that slow, and a longer timeout hides the *next* slow test rather than preventing it.

## Tests and commands run

- **Three consecutive full-suite runs** — 395 tests, all pass
- `npm run check` — exit 0
- Mutation check on the skills guard, as above

## Known limitations

Test count drops 397 → 395 because six sections × three tests became six tests × three assertions. No assertion was removed.

## Deployment impact

None. Test-only.

## Rollback notes

`git revert` restores the looping shape and the intermittent failure.

## Confidentiality review

Pass. Test-only, synthetic fixtures.

## FAC/NFAC references

FAC-HOME-005, FAC-NAV-002, NFAC-TEST-001, NFAC-TEST-002
