### PR TITLE
docs: record the P32 rollback drill and close the post-launch checklist

### DIFF
--- a/docs/release-audit.md
+++ b/docs/release-audit.md
@@ -331,3 +331,67 @@ ruleset was enough.
 
 The prohibition on direct pushes to `production` has been policy since the
 first governance commit. As of today it is enforcement.
+
+---
+
+## 2026-08-10 — P32 rollback drill and post-launch closure
+
+### Hosting rollback: verified
+
+Randi promoted the previous deployment in Vercel, confirmed the site served
+it, and rolled forward again. Straightforward, with nothing behaving
+unexpectedly.
+
+Confirmed independently after the drill: all six public routes return 200,
+`index, follow` is intact, the Hero and Work Experience render, the sitemap
+holds four entries, and no draft marker appears. The roll-forward restored the
+site completely rather than partially, which is the failure mode worth checking
+and the reason it was checked rather than assumed.
+
+### Source rollback: not exercised
+
+`docs/release-checklist.md` section 10 defines two paths. Only the hosting one
+was run.
+
+That is worth stating plainly rather than recording P32 as complete. TD 25.2 is
+explicit: a hosting rollback alone leaves source and production inconsistent.
+Vercel would be serving an older build while `production` still contains the
+change that caused the problem, so the next merge silently reintroduces it. The
+hosting rollback buys time; the source correction is what actually resolves an
+incident.
+
+Two things about that path are now different from when the checklist was
+written, and both make it *more* important to have rehearsed:
+
+- The `Protect production` ruleset requires a pull request with `quality` and
+  `e2e` green. A revert can no longer be pushed directly, so recovery takes at
+  least one full CI cycle.
+- Amending or force-pushing is no longer available as a shortcut. The
+  repository is public, so rewriting a pushed commit would permanently publish
+  the pre-rewrite SHA. Reverting forward is the only correct move.
+
+The practical consequence: **the fastest possible source correction is a revert
+pull request through CI.** That is a known, bounded cost, but it is not
+instant, and discovering it during an incident would be the wrong time.
+
+### Post-launch checklist closed
+
+| Item | State |
+|---|---|
+| Private vulnerability reporting | **Enabled** — it was still off after the section 9 pass and was caught here |
+| Dependabot opening pull requests | Confirmed: five raised, two merged, three closed by the deliberate version ceilings in `dependabot.yml` |
+| Repository description and topics | Set; eleven topics |
+| LinkedIn and email actions | Confirmed manually by Randi. Neither can be settled automatically — LinkedIn answers any non-browser client with HTTP 999 |
+
+### Standing state
+
+Open pull requests: none. Dependabot, CodeQL, and secret-scanning alerts: zero
+each. `validate:release`, `audit:prod`, and `check:links` all pass. CI green on
+`production`.
+
+### Outstanding, deliberately
+
+| Item | Status |
+|---|---|
+| Source rollback rehearsal | Not done. The one gap in P32 |
+| P33 Docker portability | Deferred by decision. Vercel does not accept container images, so Docker here would demonstrate portability rather than deliver anything. `architecture.md` already scopes it as a post-launch enhancement and the Handoff lists mandatory Docker as a non-goal |

--- a/docs/release-checklist.md
+++ b/docs/release-checklist.md
@@ -185,12 +185,36 @@ Prove recovery works *before* it is needed.
 3. Confirm the deployment reflects the revert.
 
 Hosting rollback alone leaves source and production inconsistent (TD 25.2). Any
-urgent hosting rollback must be followed by a source correction.
+urgent hosting rollback must be followed by a source correction — otherwise
+Vercel serves an older build while `production` still contains the change that
+caused the problem, and the next merge silently reintroduces it.
+
+**A pull request is the only route.** The `Protect production` ruleset blocks
+direct pushes and requires `quality` and `e2e` to pass, so the fastest possible
+source correction costs one full CI cycle. Budget for that rather than
+discovering it mid-incident.
+
+**Never amend or force-push to recover.** The repository is public, so
+rewriting a pushed commit permanently publishes the pre-rewrite SHA to event
+archives outside this repository's control. Always revert forward with a new
+commit.
 
 ---
 
 ## After launch
 
-- [ ] Enable private vulnerability reporting (now that the repository is public)
-- [ ] Confirm Dependabot is opening pull requests
-- [ ] Set repository description and topics
+Completed 2026-08-10. Recorded in [`release-audit.md`](release-audit.md).
+
+- [x] Enable private vulnerability reporting (now that the repository is public)
+- [x] Confirm Dependabot is opening pull requests — five raised, two merged,
+      three closed by the version ceilings in `dependabot.yml`
+- [x] Set repository description and topics
+
+The `Protect production` ruleset, secret scanning, push protection, Dependabot
+alerts and security updates, and CodeQL default setup were applied in the same
+pass and verified through `GET /repos/.../rules/branches/production`, which
+returns what GitHub actually evaluates.
+
+Two Advanced Security sub-features — non-provider secret patterns and validity
+checks — require a paid plan and are recorded as unavailable rather than as
+done.


### PR DESCRIPTION
## Purpose

Record the P32 rollback drill and close the post-launch checklist.

## Hosting rollback: verified

Randi promoted the previous Vercel deployment, confirmed the site served it, and rolled forward. Nothing behaved unexpectedly.

**Verified independently afterwards rather than taken on trust** — a partial roll-forward is the failure mode that matters here. All six routes 200, `index, follow` intact, Hero and Work Experience rendering, sitemap at four entries, zero draft markers.

## Source rollback: not exercised — recorded as a gap

This records **P32 as incomplete**, not complete.

TD 25.2 is explicit: a hosting rollback alone leaves source and production inconsistent. Vercel serves an older build while `production` still contains the change that caused the problem — so **the next merge silently reintroduces it**. The hosting rollback buys time; the source correction resolves the incident.

Two things changed today that make rehearsing that path *more* important, and both are now stated in the checklist where someone reaching for a shortcut mid-incident will actually see them:

- **A pull request is the only route.** The ruleset blocks direct pushes and requires `quality` + `e2e`. The fastest possible source correction now costs one full CI cycle — a bounded cost, but not instant, and not something to discover during an incident.
- **Never amend or force-push to recover.** The repository is public, so rewriting a pushed commit permanently publishes the pre-rewrite SHA to archives outside this repository. Revert forward.

## Post-launch checklist closed

| Item | Result |
|---|---|
| Private vulnerability reporting | **Was still disabled** after the §9 pass — caught here and enabled |
| Dependabot opening PRs | Confirmed: 5 raised, 2 merged, 3 closed by the deliberate version ceilings |
| Description and topics | Set, 11 topics |
| LinkedIn + email actions | Confirmed manually — neither can be settled automatically |

That first row is the useful one. **Applying settings and verifying settings are different actions**, and the §9 pass proved it by missing one.

## Changed areas

| File | Change |
|---|---|
| `docs/release-audit.md` | Fourth dated entry — drill result, the gap, and standing state |
| `docs/release-checklist.md` | Source-rollback section gains the PR-only and never-force-push constraints; after-launch items closed |

Documentation only.

## Tests and commands run

`npm run check` — exit 0, 395 tests. Site state verified live after the drill.

## Known limitations

The source rollback path remains unrehearsed. It is recorded as the one open item in P32 rather than glossed.

## Deployment impact

None.

## Rollback notes

`git revert` removes the record. No runtime effect. (Fittingly, that revert would itself have to go through a PR under the new ruleset.)

## Confidentiality review

Pass. Deployment behaviour and settings state only.

## FAC/NFAC references

FAC-OWNER-006, NFAC-REC-001, NFAC-REC-002, NFAC-REC-003, NFAC-CICD-004
