### PR TITLE
feat: add the gate lesson to the portfolio case study

### DIFF
--- a/src/content/projects/personal-developer-portfolio.ts
+++ b/src/content/projects/personal-developer-portfolio.ts
@@ -180,6 +180,15 @@ export const personalDeveloperPortfolio = defineProject({
     "two routes reached production with no primary heading at all. Tool severity describes how " +
     "badly a rule breaks a page in general; it does not know which requirements a given project " +
     "treats as launch-blocking.\n\n" +
+    "**A gate that has never run is not a gate.** Running the release pipeline end to end for " +
+    "the first time turned up four problems, and every one existed because a check had never " +
+    "been executed: a dependency audit that reported three high-severity advisories the moment " +
+    "it was finally run; a link validator wired into the release script whose file had never " +
+    "been written, so the command could only ever crash; a workflow committed and never once " +
+    "dispatched; and a broken asset that no test in the project could detect, because only a " +
+    "browser audit looks for it. The pattern was consistent. The checks that ran on every change " +
+    "were sound; the ones reserved for the moment that mattered were the broken ones, and " +
+    "reserving them is precisely what kept them broken.\n\n" +
     "**Splitting the launch gate from the development gate was the decision that made the rest " +
     "workable.** Development ran for the entire build against placeholder content, with a second " +
     "validator that refused to let any of it reach production.",


### PR DESCRIPTION
## Purpose

The release audit produced the most repeated finding of the entire build, and the case study did not record it. This adds it.

> **A gate that has never run is not a gate.**

## What it says

Running the release pipeline end to end for the first time turned up four problems, and **every one existed because a check had never been executed**:

| Finding | Why it survived |
|---|---|
| Three high-severity advisories | `audit:prod` had never been run |
| `check:links` crashed on invocation | The script was wired into `release:check` but **its file had never been written** |
| `release-audit.yml` gaps | Committed in P27, **never once dispatched** until P29 |
| A 404 on every page | No test in the project could detect it — only a browser audit looks for it |

The pattern is what makes it worth publishing, not the individual defects:

> The checks that ran on every change were sound. The ones reserved for the moment that mattered were the broken ones, and reserving them is precisely what kept them broken.

## Placement

Grouped with the other hard-won lessons rather than appended last, so the closing lesson stays the design decision that made developing against placeholders workable. That ordering ends the section on what worked rather than on what broke.

## Every claim is checkable

This case study's whole value is that a reader can verify it against the repository. All four are: the missing script, the never-dispatched workflow, the advisories, and the favicon are in the commit history and recorded in [`docs/release-audit.md`](docs/release-audit.md).

## Changed areas

`src/content/projects/personal-developer-portfolio.ts` — one paragraph added to `lessonsLearned`. Content only.

## Tests and commands run

- `npm run validate:content` — passes
- `npm run validate:release` — **passes**
- `npm run check` — exit 0, 395 tests
- `npx playwright test` — **149 passed**, 1 skipped, three engines
- Production build probe: lesson renders, markdown parsed to `<strong>`, six lesson headings present, zero draft markers

## Known limitations

None. No claim here is unverifiable from the repository.

## Deployment impact

One paragraph on `/projects/personal-developer-portfolio`. No structural change.

## Rollback notes

`git revert` removes the lesson. No runtime effect.

## Confidentiality review

Pass. Describes defects in this public repository only. No employer, client, or system is referenced.

## FAC/NFAC references

FAC-PROJECT-005, FAC-PROJECT-007, NFAC-CONTENT-002, NFAC-CONTENT-004
