### PR TITLE
feat: mark the portfolio project as production with verified confirmation

### DIFF
--- a/src/content/projects/personal-developer-portfolio.ts
+++ b/src/content/projects/personal-developer-portfolio.ts
@@ -14,12 +14,24 @@ import { defineProject } from "@/domain/content/define";
  * developer" role wording — the work was AI-accelerated under his direction,
  * and `aiUsage` discloses that explicitly rather than leaving it implied.
  *
- * deliveryStatus remains "in-development" and that is deliberate. The
- * application is deployed and verified running, but the portfolio itself has
- * not launched: most content is still Draft and indexing is disabled.
- * FAC-PROJECT-004 forbids claiming a status the work has not reached, and
- * "production" would additionally require a verified productionConfirmation
- * (TD 9.5). Revisit this at launch, not before.
+ * deliveryStatus moved from "in-development" to "production" on 2026-08-10.
+ * The previous comment here said to revisit this at launch and not before, and
+ * this is that revisit.
+ *
+ * The reasons it was held back are all now resolved: the launch content is
+ * complete, release validation passes, and indexing is enabled. FAC-PROJECT-004
+ * forbids claiming a status the work has not reached — it does not require
+ * understating one it has.
+ *
+ * TD 9.5 requires a verified productionConfirmation for this status, and the
+ * note below is a summary of the P31 production verification recorded in
+ * docs/release-audit.md. That check was performed against the live deployment
+ * rather than inferred from a green build, which is the distinction the rule
+ * exists to enforce (NFAC-CICD-004).
+ *
+ * If this project is ever taken offline, this status and its confirmation come
+ * down with it. The confirmation is a statement about the present, not a
+ * permanent award.
  *
  * Editing any claim here means re-checking it against the repository. The
  * value of this case study is that every statement in it is verifiable.
@@ -34,7 +46,7 @@ export const personalDeveloperPortfolio = defineProject({
 
   projectType: "personal",
   role: "Sole developer — requirements, architecture, implementation, testing, and delivery",
-  deliveryStatus: "in-development",
+  deliveryStatus: "production",
   period: "2026",
 
   context:
@@ -203,6 +215,18 @@ export const personalDeveloperPortfolio = defineProject({
     "skill-ai-assisted-engineering",
   ],
 
+  // TD 9.5 and FAC-PROJECT-004. Every figure here was measured against the
+  // live deployment during P31 and is recorded in docs/release-audit.md.
+  productionConfirmation: {
+    verified: true,
+    note:
+      "Verified against the live deployment rather than inferred from a successful build " +
+      "(NFAC-CICD-004). Every public route returns 200, the resume serves as a PDF, robots and " +
+      "the sitemap reflect the launched state, and the security headers are present. A Lighthouse " +
+      "audit of the homepage, the projects index, and a case study scored 97 or above for " +
+      "performance and 100 for accessibility, best practices, and SEO on all three.",
+  },
+
   confidentialityClass: "public",
 
   // Published and featured together: Technical Design 9.4 requires every
@@ -211,5 +235,5 @@ export const personalDeveloperPortfolio = defineProject({
   featured: true,
   featuredPriority: 1,
   publicationStatus: "published",
-  updatedAt: "2026-08-04",
+  updatedAt: "2026-08-10",
 });

--- a/tests/components/homepage-empty-state.test.tsx
+++ b/tests/components/homepage-empty-state.test.tsx
@@ -6,6 +6,7 @@ import { ExperienceSection } from "@/components/sections/experience-section";
 import { HeroSection } from "@/components/sections/hero-section";
 import { ProjectsSection } from "@/components/sections/projects-section";
 import { SkillsSection } from "@/components/sections/skills-section";
+import { getFeaturedProjects } from "@/domain/content/selectors";
 
 /**
  * Homepage sections against the real, unmocked selectors.
@@ -125,16 +126,45 @@ describe("Selected Projects renders both launch case studies", () => {
   });
 
   /**
-   * FAC-PROJECT-004. "Completed" is displayed for the professional work
-   * because the evidence does not support a production claim. A card that
-   * silently upgraded that label would misrepresent the work on the first
-   * screen a recruiter sees.
+   * FAC-PROJECT-004. Each card must show the status its evidence supports. The
+   * professional work is "Completed" because no production verification was
+   * performed on it; the portfolio itself is "Production" because one was, and
+   * is recorded. A card that silently upgraded its label would misrepresent the
+   * work on the first screen a recruiter sees.
+   *
+   * This reads the status attribute on each specific card rather than scanning
+   * the section's text. The previous version did the latter and was vacuous:
+   * container.textContent concatenates adjacent elements without separators, so
+   * the section reads "...Personal projectProduction. Verified...", and
+   * /\bProduction\b/ found no word boundary between "project" and "Production".
+   * It would have passed even if the professional card had been upgraded, which
+   * is the one thing it existed to catch.
    */
-  it("shows the honest delivery status on the professional card", () => {
-    const { container } = render(<ProjectsSection />);
+  function statusOf(title: string): string | null | undefined {
+    const card = screen.getByRole("link", { name: title }).closest("article");
 
-    expect(container.textContent).toContain("Completed");
-    expect(container.textContent).not.toMatch(/\bProduction\b/);
+    return card?.querySelector("[data-status]")?.getAttribute("data-status");
+  }
+
+  it("shows each card the delivery status its evidence supports", () => {
+    render(<ProjectsSection />);
+
+    expect(statusOf("Jury Process Management Integration")).toBe("completed");
+    expect(statusOf("Personal Developer Portfolio")).toBe("production");
+  });
+
+  it("never shows Production for work without a verified confirmation", () => {
+    render(<ProjectsSection />);
+
+    // The rule restated at the rendering layer: only a project carrying a
+    // productionConfirmation may display that badge.
+    for (const project of getFeaturedProjects()) {
+      const status = statusOf(project.title);
+
+      if (status === "production") {
+        expect(project.productionConfirmation?.verified, project.slug).toBe(true);
+      }
+    }
   });
 });
 

--- a/tests/content/validation.test.ts
+++ b/tests/content/validation.test.ts
@@ -234,15 +234,29 @@ describe("rule: unique featured priority", () => {
 
 describe("rule: production requires confirmation (TD 9.5)", () => {
   it("rejects Production status without a verified confirmation", () => {
+    // The confirmation must be stripped explicitly. This test previously
+    // spread a real project and set the status, which worked only while no
+    // real project was Production. Once one was, the spread carried its
+    // confirmation across and the rule stopped firing — the test passed
+    // without exercising anything.
     const [first] = projects;
+    const { productionConfirmation, ...withoutConfirmation } = first!;
+
+    expect(productionConfirmation, "fixture premise: the source record has one").toBeDefined();
+
     const content = {
       ...realContent(),
       // Bypasses the schema deliberately: this proves validation catches it
       // even if a record is ever built without the definition helper.
-      projects: [{ ...first!, deliveryStatus: "production" as const }],
+      projects: [{ ...withoutConfirmation, deliveryStatus: "production" as const }],
     };
 
     expect(rulesTriggeredBy(content)).toContain("production-requires-confirmation");
+  });
+
+  it("accepts the real content set, where Production carries its confirmation", () => {
+    // The live case: the portfolio case study is Production and confirmed.
+    expect(rulesTriggeredBy(realContent())).not.toContain("production-requires-confirmation");
   });
 
   it("accepts Production status with a verified confirmation", () => {


### PR DESCRIPTION
## Purpose

The case study's own header said to revisit `deliveryStatus` **at launch and not before**. This is that revisit.

Every reason it was held at `in-development` is resolved: launch content complete, release validation passing, indexing enabled. FAC-PROJECT-004 forbids claiming a status the work has not reached — it does not require understating one it has.

TD 9.5 requires a verified `productionConfirmation`, and the note summarises the **P31 verification already recorded** in [`docs/release-audit.md`](docs/release-audit.md): every route 200 on the live deployment, resume serving as PDF, robots and sitemap correct, security headers present, Lighthouse ≥ 97 performance and 100 accessibility across three page types.

That check ran **against the live deployment**, not inferred from a green build — the distinction NFAC-CICD-004 exists to enforce. The header also records that the status comes down if the site does: a confirmation describes the present, not a permanent award.

## Two tests were passing for the wrong reason

This is the part worth reviewing.

**1. `production-requires-confirmation`** spread a real project and set its status to production. That worked only while no real project *was* production. The moment one was, the spread carried its confirmation across and **the rule stopped firing — the test passed without exercising anything.**

Now strips the confirmation explicitly and asserts the fixture premise, so it cannot go quiet again.

**2. The card-level check was worse — it could never have failed.**

It asserted `Production` appeared nowhere in the section, via `expect(container.textContent).not.toMatch(/\bProduction\b/)`.

`textContent` concatenates adjacent elements **without separators**, so the section reads:

```
...Personal projectProduction. Verified as deployed...
```

There is no word boundary between `project` and `Production`. The regex never matched. That assertion existed to catch the *professional* case study being silently upgraded to Production — and would not have caught it.

I only found this because changing the status should have broken it, and didn't.

## The replacements

Both read the `data-status` attribute on a **specific card** rather than scanning text:

```
statusOf("Jury Process Management Integration") → "completed"
statusOf("Personal Developer Portfolio")        → "production"
```

Plus a second test restating the rule at the rendering layer: **any card showing Production must carry a verified confirmation.**

**Mutation-confirmed:** upgrading the professional project to Production now fails the assertion. Under the previous version it passed.

## Changed areas

| File | Change |
|---|---|
| `src/content/projects/personal-developer-portfolio.ts` | `production` + `productionConfirmation`; header records the revisit and the takedown condition |
| `tests/content/validation.test.ts` | Negative case built explicitly; positive case added |
| `tests/components/homepage-empty-state.test.tsx` | Card-scoped status assertions replacing the vacuous text scan |

## Tests and commands run

- `npm run validate:content` / `validate:release` — both pass
- `npm run check` — exit 0, **397 tests**
- `npx playwright test` — **149 passed**, 1 skipped, three engines
- Mutation check on the professional card, as above

## Known limitations

The confirmation is a point-in-time statement. If the deployment ever goes down, this status and its note must come down with it — recorded in the file header rather than left implicit.

## Deployment impact

The portfolio card and case study now display **Production** instead of **In Development**. No structural change.

## Rollback notes

`git revert` returns the status to `in-development` and removes the confirmation. The two repaired tests would revert with it — worth re-applying separately if so, since they fix defects unrelated to the status itself.

## Confidentiality review

Pass. The confirmation note describes this public site's own verification. No employer, client, or internal detail.

## FAC/NFAC references

FAC-PROJECT-004, FAC-PUBLISH-004, NFAC-CICD-004, NFAC-CONTENT-002, TD 9.5
