### PR TITLE
fix: give the section omission tests a timeout matching their real cost

### DIFF
--- a/tests/components/homepage-section-omission.test.tsx
+++ b/tests/components/homepage-section-omission.test.tsx
@@ -67,37 +67,55 @@ const sections = [
 ] as const;
 
 /**
- * One test per section, asserting all three properties from a single render.
+ * One test per section, asserting all three properties from a single render,
+ * with a raised timeout.
  *
- * The shape matters. This started as three tests that each looped over all six
- * sections, which meant two of them performed six full module-graph reloads
- * inside one five-second budget. Each reload resets the module registry and
- * re-imports a component, its selectors, and the content modules beneath them.
+ * Both halves of that were needed, and the first alone was not enough.
  *
- * That passed in isolation and failed intermittently in the full suite — once
- * at 11.3 seconds, while a CodeQL scan competed for CPU. A test that fails only
- * under load is worse than one that fails outright: it trains you to re-run
- * rather than to read.
+ * This began as three tests that each looped over all six sections, so two of
+ * them performed six full module-graph reloads inside one five-second budget.
+ * Restructuring to one reload per test cut the file from eighteen reloads to
+ * six and from about eleven seconds to under four. That was reported as the
+ * fix, on the strength of three consecutive passing runs.
  *
- * Now no test performs more than one reload, so none is near the timeout, and
- * the file does six reloads in total rather than eighteen. Each assertion
- * carries its own message, so a failure still names which property broke.
+ * It flaked again anyway, at 12.2 seconds.
+ *
+ * Measured rather than guessed the second time: one reload costs about 540ms
+ * on an idle machine. That is legitimate, irreducible work — resetting the
+ * module registry and re-importing a component, its selectors, and roughly
+ * 1,100 lines of content modules beneath them. Against a five-second budget it
+ * leaves nine times headroom, which sounds ample and is not when several
+ * vitest workers, a CodeQL scan, and a Lighthouse run compete for CPU.
+ *
+ * So the restructure removed the avoidable cost and the budget was still
+ * wrong. Raising a global timeout would hide the next slow test; raising it for
+ * one file whose remaining cost is measured and irreducible is just describing
+ * the work honestly.
+ *
+ * If these become slow enough to hit twenty seconds, that is a real signal
+ * about module-graph size rather than a number to raise again.
  */
+const RELOAD_TIMEOUT_MS = 20_000;
+
 describe("a section with nothing publicly eligible renders nothing", () => {
   for (const [label, moduleName, componentName] of sections) {
-    it(`${label} omits itself entirely`, async () => {
-      const container = await renderWithEmptyContent(moduleName, componentName);
+    it(
+      `${label} omits itself entirely`,
+      async () => {
+        const container = await renderWithEmptyContent(moduleName, componentName);
 
-      expect(container, `${label}: rendered something`).toBeEmptyDOMElement();
+        expect(container, `${label}: rendered something`).toBeEmptyDOMElement();
 
-      // A heading rendered outside the early return would leave "Technical
-      // Skills" announced with nothing under it (FAC-HOME-005).
-      expect(container.querySelector("h1, h2, h3, h4"), `${label}: kept a heading`).toBeNull();
+        // A heading rendered outside the early return would leave "Technical
+        // Skills" announced with nothing under it (FAC-HOME-005).
+        expect(container.querySelector("h1, h2, h3, h4"), `${label}: kept a heading`).toBeNull();
 
-      // Header links point at section ids. An id surviving an omitted section
-      // gives a keyboard user a navigation target that goes nowhere
-      // (FAC-NAV-002).
-      expect(container.querySelector("[id]"), `${label}: kept an anchor target`).toBeNull();
-    });
+        // Header links point at section ids. An id surviving an omitted section
+        // gives a keyboard user a navigation target that goes nowhere
+        // (FAC-NAV-002).
+        expect(container.querySelector("[id]"), `${label}: kept an anchor target`).toBeNull();
+      },
+      RELOAD_TIMEOUT_MS,
+    );
   }
 });


### PR DESCRIPTION
## Purpose

**The previous fix for this flake did not work, and I reported it as resolved.**

PR #31 restructured the file and I called it fixed on the strength of three consecutive passing runs. It flaked again during this session at **12.2 seconds**.

## What the restructure did and did not achieve

It was correct and insufficient. Eighteen reloads became six; the file went from ~11 s to under 4 s. That removed the *avoidable* cost. The budget was still wrong.

**Measured this time instead of reasoned about:** one module-graph reload costs **~540 ms** on an idle machine. That is legitimate, irreducible work — resetting the module registry and re-importing a component, its selectors, and ~1,100 lines of content modules beneath them.

Nine times headroom against a 5 s budget sounds ample. It is not, when several vitest workers, a CodeQL scan, and a Lighthouse run compete for CPU — which is exactly what was happening both times it failed.

## Correcting my own argument

PR #31 argued against raising the timeout because it "hides the next slow test rather than preventing it."

That holds for a **global** change. It does not hold for one file whose remaining cost has been measured and cannot be reduced further. Raising it there describes the work honestly rather than concealing it, and the comment states what a future breach of 20 s would actually mean: a real signal about module-graph size, not a number to raise again.

## Verified under the condition that caused it

Not on an idle machine this time:

- **Full suite passes with three concurrent full suites competing for CPU**
- Removing the skills omission guard still fails the assertion — coverage unchanged
- `npm run check` — exit 0, 397 tests

## Changed areas

`tests/components/homepage-section-omission.test.tsx` — per-test timeout constant and the reasoning. **Test-only.**

## Known limitations

20 s is generous by design. If these tests ever approach it, that is information about how large the content module graph has grown, and the fix then is not a bigger number.

## Deployment impact

None.

## Rollback notes

`git revert` restores the 5 s budget and the intermittent failure.

## Confidentiality review

Pass. Test-only.

## FAC/NFAC references

FAC-HOME-005, FAC-NAV-002, NFAC-TEST-001, NFAC-TEST-002
