### PR TITLE
docs: record the enforcement-era rules in the project instructions

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,13 +19,63 @@ For GitHub repository settings and security configuration, follow:
 Never modify application or documentation files directly on `production`.
 Create a short-lived task branch first.
 
+This is now enforced as well as required. The `Protect production` ruleset is
+active with no bypass actors, so it applies to the repository owner too: pull
+request required, squash merge only, `quality` and `e2e` must pass, linear
+history, force pushes and deletions blocked.
+
+## Never Rewrite Pushed History
+
+This repository is public. Amending or force-pushing a commit that has been
+pushed permanently publishes the pre-rewrite SHA to event archives outside this
+repository's control.
+
+Fix forward with a new commit. Always. There is no shortcut worth this, and
+recovery during an incident is exactly when the temptation appears — see the
+rollback section of `docs/release-checklist.md`.
+
 ## Merge Authority
 
 Claude may prepare commits, push a task branch, and create or update a pull
 request when authorized.
 
 Claude must not merge a pull request into `production` without Randi Fajar
-Wicaksono's explicit approval in the current conversation.
+Wicaksono's explicit approval in the current conversation. Passing CI is
+necessary, never sufficient. Approval of one pull request is not approval of the
+next.
+
+## Verification Before Pushing
+
+Never report that a check passed without having observed its output.
+
+Run the whole gate, not the convenient part of it:
+
+```bash
+npm run check      # format, lint, typecheck, validate:content, tests, build
+npm run test:e2e   # three engines, against a production build
+```
+
+Unit tests passing is not the suite passing — a change with green unit tests
+once broke CI because the end-to-end suite was not run. After a merge, verify
+the merged tree rather than the branch: two branches that each pass alone can
+break the moment they meet.
+
+For an assertion that guards something important, break what it guards and
+confirm it complains. Two tests in this repository were green for the entire
+build while testing nothing.
+
+## Content Truthfulness
+
+Never invent a professional claim: employer, dates, job title, metric, outcome,
+or the technologies used on a specific project. If a fact is missing, ask for
+it. A bracketed question is better than a confident guess.
+
+`deliveryStatus` describes reality, and `production` requires a verified
+`productionConfirmation` (FAC-PROJECT-004, TD 9.5). Personal and team
+responsibility render as separate blocks so shared work is never read as
+individual work (FAC-PROJECT-003).
+
+See `docs/content-authoring.md` before editing anything under `src/content/`.
 
 ## Confidentiality
 


### PR DESCRIPTION
## Purpose

`CLAUDE.md` described policy that was not yet enforcement, and predated several rules the v1 build taught. It still delegates detail to `docs/governance/` — what is added is the set of constraints a contributor needs *before* reading further.

## What's new

**Branch rule** now records that `Protect production` is active with **no bypass actors**, so it applies to the repository owner too. The prohibition on direct pushes predates the enforcement and does not depend on it.

**Never rewrite pushed history** — new, and it matters most during an incident, which is exactly when the shortcut looks attractive. The repository is public: amending or force-pushing a pushed commit permanently publishes the pre-rewrite SHA to archives outside this repository's control.

**Verification before pushing** — what the build actually taught:

- Never report a check as passed without observing its output
- Run the whole gate, not the convenient part. A change with green unit tests once broke CI because the e2e suite had not been run
- Verify the merged tree, not the branch. Two branches that each pass alone can break when they meet
- For an assertion that guards something important, **break what it guards and confirm it complains**. Two tests here were green for the entire build while testing nothing

**Content truthfulness** — never invent an employer, date, title, metric, outcome, or the technologies used on a specific project. Points at the delivery-status and responsibility-separation requirements that back it.

## Claims were checked, not recalled

Verified against live repository settings before writing them down:

```
bypass actors:    none
required checks:  quality, e2e
merge methods:    squash
```

## Changed areas

`CLAUDE.md`. Documentation only.

## Tests and commands run

`npm run check` — exit 0, 397 tests.

## Deployment impact

None.

## Rollback notes

`git revert` returns the file to describing policy without enforcement.

## Confidentiality review

Pass. This file is public; it states rules and points at public governance documents.

## FAC/NFAC references

NFAC-MAINT-004, NFAC-CONTENT-002
