### PR TITLE
docs: add the v1.1 corrective release handoff

### DIFF
--- a/docs/handoff/V1.1_HANDOFF.md
+++ b/docs/handoff/V1.1_HANDOFF.md
@@ -1,0 +1,1131 @@
+# Developer Portfolio V1.1 — Claude Handoff
+
+> **Purpose:** Start a fresh Claude Code session to implement a focused V1.1 correction release for the deployed developer portfolio.
+>
+> **Repository:** `randifajar/developer-portfolio`
+>
+> **Production branch:** `production`
+>
+> **Current deployed portfolio:** `https://developer-portfolio-delta-three.vercel.app/`
+>
+> **Release type:** Corrective / positioning / recruiter-UX improvement
+>
+> **Not a redesign:** V1.1 must preserve the existing architecture and "Quiet Engineering" design direction. Larger visual and interaction redesign work belongs to V2.
+
+---
+
+## 1. Context
+
+The portfolio V1 is already deployed and usable for job applications.
+
+Its strongest qualities are:
+
+- detailed engineering case studies rather than shallow project cards;
+- confidentiality-aware publication rules;
+- explicit separation between publication status, delivery status, and confidentiality;
+- typed local content validated with Zod;
+- static generation through Next.js App Router;
+- Server Components by default;
+- automated testing and release validation;
+- Playwright end-to-end testing;
+- accessibility verification;
+- GitHub Actions CI/CD;
+- a clear AI-assisted engineering model where AI accelerates the work but does not own engineering decisions.
+
+V1.1 is **not** intended to replace those foundations.
+
+The purpose of V1.1 is to correct a small group of issues found during an external portfolio review so that the deployed portfolio more accurately represents Randi's current professional position as a backend developer with more than two years of hands-on experience.
+
+The portfolio should continue to communicate:
+
+> A backend developer who works across requirements, APIs, databases, integrations, deployment environments, troubleshooting, verification, and technical documentation, while using AI responsibly as an engineering accelerator.
+
+---
+
+# 2. Primary V1.1 Goal
+
+Improve recruiter-facing clarity and consistency without turning the correction release into a UI redesign.
+
+After V1.1, a recruiter should be able to understand within a short scan:
+
+1. Randi is primarily a **Backend Developer**.
+2. He has **2+ years of progressive professional experience**, from internship to contract to full-time.
+3. His strongest professional evidence is his **work experience and engineering case studies**.
+4. His core technical stack includes **Node.js, GraphQL, MongoDB, APIs, background jobs, integrations, Docker, and related backend infrastructure**.
+5. AI is part of his workflow, but **engineering ownership remains with him**.
+6. The repository and website accurately state that V1 is already deployed to production.
+
+---
+
+# 3. Source of Truth
+
+Before changing code, inspect the current repository rather than relying only on this handoff.
+
+At minimum, read:
+
+```text
+README.md
+
+src/app/page.tsx
+src/app/globals.css
+
+src/content/profile.ts
+src/content/site.ts
+src/content/experience.ts
+src/content/skills.ts
+src/content/ai-practices.ts
+src/content/resume.ts
+
+src/content/projects/index.ts
+src/content/projects/jury-process-management.ts
+src/content/projects/personal-developer-portfolio.ts
+
+src/components/sections/hero-section.tsx
+src/components/sections/about-section.tsx
+src/components/sections/projects-section.tsx
+src/components/sections/experience-section.tsx
+src/components/sections/skills-section.tsx
+src/components/sections/ai-workflow-section.tsx
+src/components/sections/contact-section.tsx
+
+src/components/project/project-card.tsx
+
+docs/architecture.md
+docs/release-checklist.md
+docs/product/
+docs/governance/
+docs/plans/
+```
+
+Also search the repository for references to:
+
+```text
+Backend-Focused Full-Stack Developer
+backend-focused full-stack
+Full-Stack Developer
+remote opportunities
+seeking remote
+not yet deployed
+Vercel connection is pending
+implementation in progress
+Draft placeholder
+DEC-025
+```
+
+Do not change only the visible component if the same decision is documented elsewhere.
+
+---
+
+# 4. Current Issues Confirmed Before V1.1
+
+## Issue 1 — README still describes a pre-launch state
+
+The current `README.md` still says:
+
+```text
+Public URL: not yet deployed. Vercel connection is pending.
+```
+
+and describes the application as:
+
+```text
+implementation in progress
+```
+
+with Draft placeholder content.
+
+This is no longer accurate because V1 is deployed.
+
+The README also still lists Vercel as:
+
+```text
+Hosting | Vercel (planned)
+```
+
+and contains other pre-launch wording such as release validation being expected to fail during development.
+
+### Why this matters
+
+The portfolio repository is public and may be opened by recruiters or technical interviewers after visiting the deployed site.
+
+A live portfolio whose README claims that it is not deployed creates an avoidable credibility problem.
+
+### Required V1.1 outcome
+
+Update all stale launch/deployment wording in the README so it reflects the actual production state.
+
+Suggested top-level wording:
+
+```markdown
+**Live Portfolio:** https://developer-portfolio-delta-three.vercel.app/
+
+**Status:** Production
+
+Version 1 is deployed on Vercel with automated quality gates covering
+formatting, linting, strict type checking, content validation, tests,
+production builds, end-to-end tests, and accessibility checks.
+```
+
+Also audit the rest of the README for statements that were correct during development but became false after production launch.
+
+Do not rewrite the entire README merely for style.
+
+---
+
+# 5. Professional Positioning Correction
+
+## Issue 2 — The portfolio currently positions Randi as a full-stack developer first
+
+Current `src/content/profile.ts` uses:
+
+```ts
+professionalTitle: "Backend-Focused Full-Stack Developer"
+```
+
+and the headline begins with:
+
+```text
+Backend-focused full-stack developer...
+```
+
+The current target roles include:
+
+```text
+Backend Developer
+Full-Stack Developer
+Software Engineer
+```
+
+### Why this matters
+
+Randi's current professional positioning is now intentionally consistent across LinkedIn, CV, portfolio, and job applications:
+
+> **Backend Developer**
+
+He is capable of working across the stack, but full-stack development should not be presented as his primary career identity.
+
+### Required V1.1 outcome
+
+Use:
+
+```text
+Backend Developer
+```
+
+as the primary professional title.
+
+Recommended target roles:
+
+```text
+Backend Developer
+Backend Engineer
+Software Engineer
+```
+
+Do not use `Full-Stack Developer` as a primary target role in V1.1.
+
+Full-stack capability may still be mentioned contextually where truthful, but it must not compete with the backend-first positioning.
+
+### Preferred principle
+
+Use:
+
+> Backend Developer who can work across application boundaries.
+
+Avoid:
+
+> Full-Stack Developer who happens to prefer backend.
+
+---
+
+# 6. Hero Messaging Correction
+
+## Issue 3 — Hero copy is too remote-specific
+
+The current headline explicitly says Randi is:
+
+```text
+seeking remote backend and software engineering roles
+```
+
+and the profile uses:
+
+```text
+Open to remote opportunities
+```
+
+### Why this matters
+
+The portfolio should not unnecessarily exclude relevant backend opportunities solely because they are hybrid or otherwise not described as remote.
+
+V1.1 should remove the **remote-only implication** without inventing availability that Randi has not confirmed.
+
+### Required V1.1 outcome
+
+Use neutral opportunity language.
+
+Recommended headline direction:
+
+```text
+Backend Developer building Node.js, GraphQL, and MongoDB systems.
+```
+
+or:
+
+```text
+Backend Developer building Node.js, GraphQL, and MongoDB systems, open to backend and software engineering opportunities.
+```
+
+For the secondary availability line, prefer neutral wording such as:
+
+```text
+Open to opportunities
+```
+
+or remove the availability phrase if the page remains clear without it.
+
+### Do not invent
+
+Do not automatically claim:
+
+- open to onsite;
+- open to relocation;
+- open to hybrid;
+- worldwide availability;
+- visa availability.
+
+Those facts have not been confirmed for this release.
+
+---
+
+# 7. Homepage About Section
+
+## Issue 4 — The About content is too long for recruiter scanning
+
+The current summary contains multiple substantial paragraphs covering:
+
+- career progression;
+- backend stack;
+- aggregation pipelines;
+- integrations;
+- environment troubleshooting;
+- AI usage;
+- engineering ownership;
+- job-search targets.
+
+The content is strong, but much of it is repeated later in:
+
+- Work Experience;
+- Skills;
+- AI-Assisted Engineering;
+- individual project case studies.
+
+### V1.1 goal
+
+The homepage About section should provide orientation, not duplicate the entire LinkedIn summary.
+
+Target approximately **100–150 words**.
+
+### Recommended summary
+
+Use this as the baseline unless current content-model constraints require a small adjustment:
+
+```text
+I'm a Backend Developer with more than two years of hands-on experience,
+progressing from internship to contract and full-time roles. I build and
+maintain Node.js, GraphQL, and MongoDB services for academic and administrative
+workflows, including APIs, aggregation pipelines, background jobs, data
+processing, and service integrations.
+
+My work often crosses application and environment boundaries: I trace database
+and CORS issues, investigate memory and background-job failures, and validate
+changes across development, staging, pre-production, and production. I use
+AI-assisted tools to accelerate analysis and implementation while retaining
+responsibility for requirements, technical decisions, review, security,
+regression checking, and final verification.
+```
+
+### Content rule
+
+Do not add a final sentence that loudly announces:
+
+```text
+I am currently looking for...
+```
+
+The hero already communicates availability.
+
+Avoid repeating target roles inside the prose if they remain visible as structured tags.
+
+---
+
+# 8. Homepage Information Hierarchy
+
+## Issue 5 — Projects currently appear before professional experience
+
+Current order in `src/app/page.tsx`:
+
+```text
+Hero
+About
+Projects
+Experience
+Skills
+AI-Assisted Engineering
+Contact
+```
+
+The existing comment says this comes from `DEC-025`.
+
+### Why review this
+
+The portfolio was initially structured when project evidence needed to carry more weight.
+
+Randi now has more than two years of professional experience and a clear progression:
+
+```text
+Internship → Contract → Full-time Backend Developer
+```
+
+For an experienced developer, professional experience should normally be seen before project case studies.
+
+### Recommended V1.1 order
+
+```text
+Hero
+About
+Work Experience
+Selected Projects
+Technical Skills
+AI-Assisted Engineering
+Contact
+```
+
+### Implementation rule
+
+This is a **content hierarchy change**, not a redesign.
+
+Before changing the order:
+
+1. find `DEC-025` and every test/specification that depends on the previous order;
+2. confirm the new order does not break navigation, heading structure, anchor behaviour, screenshot expectations, or acceptance criteria;
+3. update the decision/specification documentation consistently if the order changes;
+4. add/update tests where necessary.
+
+If this unexpectedly requires a broad redesign rather than a straightforward hierarchy correction, document the reason and defer it to V2 instead of expanding V1.1.
+
+The default expectation is that the order **should be changed** unless repository constraints reveal a meaningful reason not to.
+
+---
+
+# 9. Project Card Recruiter Scanability
+
+## Issue 6 — Project cards should communicate value faster
+
+Current `ProjectCard` already shows:
+
+- project type;
+- delivery status;
+- project title;
+- summary;
+- role;
+- technology tags;
+- `View case study`.
+
+That foundation should remain.
+
+### V1.1 goal
+
+Make the card easier to understand during a 5–10 second recruiter scan without introducing a new complex data model.
+
+A recruiter should quickly see:
+
+```text
+What is this?
+Was it professional or personal?
+What was Randi's role?
+What type of engineering work does it demonstrate?
+Which core technologies were involved?
+Can I open the case study?
+```
+
+### Preferred adjustments
+
+Keep the existing fields if possible.
+
+Improve hierarchy rather than inventing fields.
+
+Recommended visible order:
+
+```text
+Project type + delivery status
+Project title
+Role / responsibility
+Short summary
+Core technology tags
+View case study
+```
+
+Consider changing:
+
+```text
+Role:
+```
+
+to:
+
+```text
+My role:
+```
+
+if it improves clarity.
+
+The role should remain clearly separate from the overall project outcome so team work is not misrepresented as individual ownership.
+
+### Avoid in V1.1
+
+Do not introduce a new `focusAreas` schema field solely to decorate cards unless a strong existing architectural reason supports it.
+
+Do not invent business metrics.
+
+Do not add internal screenshots.
+
+Do not publish private repository links.
+
+Do not reduce confidentiality safeguards to make a card visually richer.
+
+---
+
+# 10. AI-Assisted Engineering Emphasis
+
+## Issue 7 — AI is a differentiator but should not become the main identity
+
+The existing AI-Assisted Engineering section is strong because it explicitly separates:
+
+- AI-supported activity;
+- tool;
+- purpose;
+- human responsibility;
+- verification.
+
+Keep that conceptual model.
+
+### V1.1 goal
+
+The page should communicate:
+
+> Randi is a backend engineer who uses AI responsibly.
+
+It should not communicate:
+
+> Randi is primarily an AI-tool operator who also works on backend systems.
+
+### Required behaviour
+
+Keep AI-Assisted Engineering **after**:
+
+1. Work Experience;
+2. Projects;
+3. Technical Skills.
+
+Do not move it higher.
+
+Do not add tool logos.
+
+Do not increase the amount of AI marketing copy.
+
+### Visual adjustment
+
+Review whether the current 2x2 card treatment gives this section more visual weight than Work Experience or Projects.
+
+If yes, reduce its visual dominance using existing design primitives.
+
+Possible approaches:
+
+- slightly denser cards;
+- less vertical space;
+- simpler headings;
+- more compact supporting copy;
+- restrained background treatment.
+
+Do not redesign the entire section.
+
+Preserve:
+
+- human responsibility;
+- verification method;
+- corrected-assumption evidence where present;
+- truthful disclosure of Codex, Claude Code, and ChatGPT.
+
+---
+
+# 11. What Must Not Change in V1.1
+
+The following are explicitly outside scope.
+
+## Architecture
+
+Do not replace:
+
+- Next.js App Router;
+- typed TypeScript content modules;
+- Zod validation;
+- selector-based publication flow;
+- static generation;
+- current content-domain boundaries.
+
+## Confidentiality model
+
+Do not weaken or remove the independent concepts of:
+
+- publication status;
+- delivery status;
+- confidentiality.
+
+Private/restricted content must remain impossible to publish accidentally.
+
+## Major visual redesign
+
+Do not implement:
+
+- a new visual identity;
+- dark mode;
+- theme switching;
+- animation-heavy interactions;
+- new navigation concept;
+- page-layout overhaul;
+- glassmorphism;
+- 3D effects;
+- major hero redesign;
+- UI component library migration.
+
+Those belong to V2.
+
+## New portfolio projects
+
+Do not add a third project as part of V1.1.
+
+A future independent backend project remains a separate initiative.
+
+## Backend platform additions
+
+Do not add:
+
+- database;
+- CMS;
+- authentication;
+- admin dashboard;
+- contact backend;
+- runtime API;
+- analytics platform;
+
+unless required to fix a confirmed V1.1 regression, which is not expected.
+
+---
+
+# 12. Existing Strengths That Must Be Preserved
+
+Do not accidentally "simplify" away the things that make V1 credible.
+
+Preserve:
+
+- detailed case-study structure;
+- professional vs personal project distinction;
+- delivery-status truthfulness;
+- production confirmation requirement;
+- confidentiality checks;
+- no private/restricted content in the public repository;
+- static generation of eligible projects;
+- no route/sitemap/metadata leakage for unpublished projects;
+- accessibility handling;
+- skip-to-content behaviour;
+- keyboard focus visibility;
+- reduced-motion handling;
+- WCAG-conscious color decisions;
+- tests for content-domain behaviour;
+- release-validation behaviour;
+- CI quality gates;
+- clear separation between AI assistance and human ownership.
+
+---
+
+# 13. Suggested Implementation Order
+
+Use a short-lived branch from the latest `production`.
+
+Suggested branch:
+
+```text
+fix/portfolio-v1.1
+```
+
+Before editing:
+
+```bash
+git checkout production
+git pull
+git status
+git checkout -b fix/portfolio-v1.1
+```
+
+Then implement in this order.
+
+## Phase 1 — Establish current state
+
+1. Read project documentation and existing decisions.
+2. Search for all stale pre-launch wording.
+3. Search for all full-stack/remote-first positioning.
+4. Find `DEC-025` and related tests/documentation.
+5. Run the current verification suite before changes.
+6. Record baseline failures, if any.
+
+## Phase 2 — Content corrections
+
+1. Update README deployment status.
+2. Update professional title.
+3. Update hero headline.
+4. Update neutral availability wording.
+5. Update target roles.
+6. Shorten About summary.
+7. Update any metadata/social-preview copy that still uses the old positioning.
+
+## Phase 3 — Hierarchy corrections
+
+1. Change homepage section order if repository review confirms it is safely in V1.1 scope.
+2. Update the decision/specification that owns section order.
+3. Update tests dependent on the order.
+
+## Phase 4 — Recruiter scanability
+
+1. Refine project-card content hierarchy.
+2. Keep role attribution explicit.
+3. Preserve status and technology visibility.
+4. Review mobile and desktop scanning.
+
+## Phase 5 — AI section refinement
+
+1. Preserve all ownership/verification information.
+2. Reduce visual dominance only if current hierarchy warrants it.
+3. Do not alter the underlying AI-practice truth model.
+
+## Phase 6 — Full verification
+
+Run all required checks.
+
+---
+
+# 14. Acceptance Criteria
+
+V1.1 is complete only when all of the following are true.
+
+## AC-01 — README production state
+
+- README contains the actual live portfolio URL.
+- README no longer says Vercel is pending.
+- README no longer says the application is merely in development.
+- Hosting is described as deployed/production rather than planned.
+- Other pre-launch statements have been reviewed and corrected where stale.
+
+## AC-02 — Backend-first identity
+
+- Primary title is `Backend Developer`.
+- Hero does not identify Randi primarily as a Full-Stack Developer.
+- Target roles prioritize Backend Developer / Backend Engineer / Software Engineer.
+- No conflicting public metadata retains the previous primary positioning unless deliberately historical.
+
+## AC-03 — Opportunity wording
+
+- Hero no longer implies that only remote opportunities are acceptable.
+- No unconfirmed onsite/hybrid/relocation claim is invented.
+
+## AC-04 — About scanability
+
+- Homepage About is approximately 100–150 words.
+- It communicates experience level, backend specialization, representative work, and engineering ownership.
+- It does not duplicate the full AI section or Experience section.
+
+## AC-05 — Homepage hierarchy
+
+Preferred final order:
+
+```text
+Hero
+About
+Work Experience
+Selected Projects
+Technical Skills
+AI-Assisted Engineering
+Contact
+```
+
+If not changed, the implementation report must contain a concrete repository-backed reason explaining why it was intentionally deferred to V2.
+
+## AC-06 — Project cards
+
+- Professional/personal type remains visible.
+- Delivery status remains visible.
+- Role attribution remains explicit.
+- Summary remains concise.
+- Core technologies remain visible.
+- Case-study action remains obvious.
+- No new confidentiality risk is introduced.
+
+## AC-07 — AI positioning
+
+- AI-Assisted Engineering remains present.
+- It remains below professional evidence and skills.
+- Human responsibility and verification remain explicit.
+- No increased AI marketing or vendor decoration is introduced.
+
+## AC-08 — No regression
+
+- No published project becomes inaccessible.
+- No Draft/private/restricted content becomes publicly reachable.
+- Sitemap behaviour remains correct.
+- Metadata behaviour remains correct.
+- Existing resume link still works.
+- Navigation anchors still work.
+- Mobile navigation still works.
+- Keyboard navigation remains functional.
+- Heading structure remains valid.
+- Existing accessibility guarantees remain intact.
+
+---
+
+# 15. Verification Requirements
+
+Do not claim V1.1 is complete based only on a green build.
+
+Use the project's actual scripts from `package.json`. Verify their exact names before running them.
+
+At minimum, based on the current repository workflow, expect to run:
+
+```bash
+npm ci
+npm run check
+npm run validate:content
+npm run validate:release
+npm run test:run
+npm run build
+npm run test:e2e
+npm run audit:prod
+```
+
+Do not blindly duplicate work if `npm run check` already includes some commands. The final report should state exactly what ran.
+
+Also inspect:
+
+```bash
+git status
+git diff --check
+git diff
+```
+
+### Manual verification
+
+Test the built/deployed site for:
+
+- desktop;
+- mobile;
+- keyboard navigation;
+- hero copy;
+- About length/readability;
+- homepage section order;
+- project-card scanability;
+- project detail routes;
+- Work Experience;
+- AI-Assisted Engineering;
+- resume link;
+- external links;
+- 404 behaviour;
+- sitemap;
+- social metadata;
+- contact section.
+
+### Accessibility
+
+Run the established accessibility checks.
+
+Do not lower severity thresholds just to make CI pass.
+
+If a V1.1 visual change causes an accessibility failure, fix the implementation rather than weakening the test.
+
+---
+
+# 16. Production Verification
+
+A successful Vercel deployment is not enough.
+
+After merge/deployment:
+
+1. open the actual production URL;
+2. verify the new title and headline;
+3. verify the About text;
+4. verify homepage hierarchy;
+5. verify both project cards;
+6. verify Work Experience;
+7. verify AI section;
+8. verify resume;
+9. verify project detail pages;
+10. verify unknown/unpublished project behaviour;
+11. verify metadata and sitemap;
+12. record production verification using the repository's established release process.
+
+If `productionConfirmation` or release-audit documentation needs to reflect V1.1, update it according to the existing schema/rules rather than inventing a parallel process.
+
+---
+
+# 17. Confidentiality Rules
+
+This is a public repository.
+
+Therefore:
+
+> Draft does not mean private.
+
+Do not place any unsafe material into the repository even if the content is marked Draft.
+
+Never add:
+
+- raw Claude sessions;
+- raw Codex sessions;
+- company source code;
+- private GitHub URLs;
+- internal issue/ticket URLs;
+- customer or student data;
+- real internal database names if sensitive;
+- credentials;
+- API keys;
+- private IP addresses;
+- internal architecture diagrams;
+- unsanitized application screenshots;
+- proprietary PRDs;
+- confidential company identifiers.
+
+Professional case studies must remain sanitized.
+
+If a claim cannot be made without exposing private information, omit or generalize it.
+
+---
+
+# 18. Truthfulness Rules
+
+Do not invent:
+
+- impact numbers;
+- performance gains;
+- user counts;
+- record counts;
+- ownership;
+- production status;
+- team size;
+- responsibilities;
+- technologies;
+- availability;
+- employment details.
+
+Use wording such as:
+
+```text
+Contributed to...
+Worked on...
+Designed backend components for...
+Implemented...
+Investigated...
+Supported...
+```
+
+where the work was collaborative.
+
+Use sole-ownership wording only for work where sole ownership is already verified, such as the personal portfolio project where that status has been explicitly documented.
+
+---
+
+# 19. V2 Boundary
+
+When a possible improvement appears during V1.1, classify it before implementing it.
+
+## Belongs to V1.1
+
+- factual correction;
+- stale content correction;
+- backend-positioning consistency;
+- recruiter-facing copy refinement;
+- homepage hierarchy correction;
+- small project-card hierarchy improvements;
+- small visual-weight adjustment;
+- tests required by those corrections.
+
+## Belongs to V2
+
+- full UI/UX redesign;
+- new visual branding;
+- new color system;
+- new typography system;
+- dark mode;
+- animation system;
+- new navigation architecture;
+- major page-layout change;
+- major responsive redesign;
+- new project presentation model;
+- interactive case-study visualizations;
+- large component refactor done only for aesthetics.
+
+Record useful V2 ideas separately.
+
+Do not implement them in this branch.
+
+---
+
+# 20. Expected Claude Working Style
+
+Before implementation:
+
+1. inspect the repository;
+2. read the relevant documentation;
+3. identify which decisions/specifications govern each affected area;
+4. produce a short V1.1 implementation plan;
+5. explicitly identify any conflicts between this handoff and repository source-of-truth;
+6. do not edit until the plan is internally consistent.
+
+During implementation:
+
+- make focused changes;
+- preserve established patterns;
+- update tests with behaviour changes;
+- do not perform unrelated refactors;
+- review the diff after each logical phase;
+- treat AI output as proposed work, not automatically correct work.
+
+Before committing:
+
+- show the complete changed-file list;
+- show verification results;
+- identify regression risks;
+- identify any V2 ideas deliberately deferred;
+- identify any acceptance criteria not satisfied.
+
+Do not push or merge merely because tests pass.
+
+---
+
+# 21. Expected Final V1.1 Report
+
+At the end of the implementation session, produce:
+
+```markdown
+# Portfolio V1.1 Implementation Report
+
+## Summary
+What changed and why.
+
+## Files Changed
+Every changed file and its responsibility.
+
+## Issue Resolution
+- README deployment state
+- Backend positioning
+- Opportunity wording
+- About scanability
+- Homepage hierarchy
+- Project-card scanability
+- AI-section emphasis
+
+## Tests and Verification
+Exact commands and results.
+
+## Accessibility
+Checks performed and findings.
+
+## Security / Confidentiality Review
+Confirmation that no private material was introduced.
+
+## Regression Review
+What existing behaviour was specifically checked.
+
+## Production Verification
+Actual deployed checks, not merely build success.
+
+## Deferred to V2
+UI/UX improvements intentionally excluded from V1.1.
+
+## Remaining Risks
+Anything not fully verified.
+```
+
+---
+
+# 22. Definition of Done
+
+Portfolio V1.1 is done when:
+
+- the public README matches reality;
+- the professional identity is consistently backend-first;
+- the hero no longer unnecessarily limits opportunities to remote roles;
+- About is shorter and more scannable;
+- professional experience has the correct recruiter-facing priority;
+- project cards communicate responsibility and technical relevance quickly;
+- AI remains a useful differentiator without overshadowing backend engineering;
+- all relevant source documentation is consistent;
+- all automated quality gates pass;
+- accessibility remains intact;
+- confidentiality guarantees remain intact;
+- production behaviour is manually verified;
+- V2 ideas remain deferred rather than quietly expanding V1.1.
+
+---
+
+# 23. Suggested Fresh-Session Kickoff Prompt
+
+Use the following message when opening the new Claude Code session:
+
+```text
+We are starting Developer Portfolio V1.1.
+
+First, read the V1.1 handoff completely and inspect the current production
+branch before making any changes.
+
+The purpose of V1.1 is a focused corrective release based on an external
+portfolio review. It is NOT the V2 UI/UX redesign.
+
+I expect you to:
+1. understand the current repository architecture and documented decisions;
+2. compare the current implementation against every V1.1 acceptance criterion;
+3. identify affected files, tests, and documentation;
+4. create a detailed but scoped implementation plan;
+5. preserve confidentiality, accessibility, publication, and release guarantees;
+6. implement only the approved V1.1 scope;
+7. verify the complete change with the existing quality gates and production
+   release process;
+8. produce the required V1.1 implementation report.
+
+Do not start editing until you have completed repository analysis and shown the
+implementation plan.
+
+Do not introduce V2 redesign work into this branch.
+
+The handoff is the product intent, but the current repository is the technical
+source of truth. If they conflict, report the conflict explicitly instead of
+guessing.
+```
+
+---
+
+## Final Principle
+
+V1 already has substance.
+
+V1.1 should make that substance easier to understand.
+
+Do not attempt to make the portfolio impressive by adding noise.
+
+Make the existing engineering evidence:
+
+- more accurate;
+- easier to scan;
+- more consistent;
+- more defensible.
+
+Then stop.
+
+V2 is where the larger UI/UX evolution belongs.


### PR DESCRIPTION
## Purpose

Randi's v1.1 handoff, written from an external portfolio review. It scopes a focused corrective release sitting between completed v1 and the v2 UI/UX evolution.

Covers: README accuracy, backend-first positioning, neutral opportunity wording, a shorter About, homepage hierarchy, project-card scanability, and the visual weight of the AI section.

## Read in full before committing

This repository is public and I did not write this file, so it was **read completely and put through the confidentiality gate** rather than assumed safe because it is a handoff.

Scanned across 1,131 lines for:

| | Result |
|---|---|
| Internal identifiers (`SAT_`, `ADMTC`, `*_NN` patterns) | clean |
| Credentials, API keys, tokens, connection strings | clean |
| Internal or private-network URLs | clean |
| Employer names, personal names, email addresses | clean |
| External URLs referenced | one — the public site itself |

## The part most likely to matter under pressure

Section 19 draws the v1.1/v2 boundary explicitly: factual correction and recruiter-facing clarity belong to v1.1; a new visual identity, colour or type system, dark mode, animation, or navigation architecture belongs to v2. It requires classifying an improvement *before* implementing it.

It also states that the handoff is product intent while **the repository is the technical source of truth**, and that a conflict is reported rather than guessed at.

## Its first issue is verified and live right now

`README.md` describes a pre-launch state in **five** places:

```
line  11:  **Public URL:** not yet deployed. Vercel connection is pending.
line  13:  **Status:** implementation in progress
line  33:  | Hosting | Vercel (planned) |
line  85:  Launch gate — expected to fail until content is final
line 174:  expected to fail during development
```

Release validation now passes and the site is deployed. **A recruiter who visits the live site and then opens this repository currently reads that it is not deployed.**

Left for v1.1 to fix through its own process rather than corrected here — that release exists to handle it, and pre-empting it would blur the boundary the document just drew.

## Changed areas

`docs/handoff/V1.1_HANDOFF.md` — new. Documentation only.

## Tests and commands run

`npm run check` — exit 0, 397 tests. Prettier clean.

## Known limitations

The README staleness is documented but not fixed. That is deliberate, and stated above so it is a decision rather than an oversight.

## Deployment impact

None.

## Rollback notes

`git revert` removes the document.

## Confidentiality review

Pass, and performed against the full text rather than sampled. Details above.

## FAC/NFAC references

NFAC-MAINT-004, NFAC-CONTENT-002, NFAC-SEC-002
