### PR TITLE
fix: correct the README statements that stopped being true at launch

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,15 @@ skills, and an account of AI-assisted engineering practice — with the
 truthfulness and confidentiality rules enforced in code rather than left to
 review.
 
-**Public URL:** not yet deployed. Vercel connection is pending.
+**Live:** <https://developer-portfolio-delta-three.vercel.app/>
 
-**Status:** implementation in progress. The application builds and is fully
-tested; published content is still Draft placeholder text, so the site
-intentionally renders as chrome only. `npm run validate:release` reports exactly
-what remains.
+**Status:** Production. Version 1 is deployed, indexed, and verified against
+[`docs/release-checklist.md`](docs/release-checklist.md) rather than inferred
+from a successful build. `npm run release:check` passes end to end: formatting,
+linting, strict type checking, content validation, unit and component tests, a
+production build, release validation, link validation, end-to-end and
+accessibility tests across three browser engines, and a production dependency
+audit.
 
 ---
 
@@ -30,7 +33,7 @@ what remains.
 | Rich text  | react-markdown with raw HTML disabled                    |
 | Testing    | Vitest, Testing Library, Playwright, axe-core            |
 | CI         | GitHub Actions                                           |
-| Hosting    | Vercel (planned)                                         |
+| Hosting    | Vercel, deployed from `production`                       |
 
 Framework versions are pinned exactly — no caret ranges — so builds are
 reproducible.
@@ -82,7 +85,7 @@ a secret. It falls back to `http://localhost:3000` in development.
 | `npm run test:run`         | Unit and component tests                                      |
 | `npm run test:e2e`         | End-to-end and accessibility tests against a production build |
 | `npm run validate:content` | Structural content validation                                 |
-| `npm run validate:release` | Launch gate — expected to fail until content is final         |
+| `npm run validate:release` | Launch gate — content completeness and placeholder scan       |
 | `npm run audit:prod`       | Production dependency audit                                   |
 
 `npm run check` is what CI runs. Run it before opening a pull request.
@@ -152,10 +155,16 @@ fail the run.
 
 Two tests are load-bearing rather than routine:
 
-- An unknown slug and a Draft slug must return **byte-identical** responses.
-  Two 404s with different copy would still leak.
-- Release validation must **fail** on Draft content, and a completed-launch
-  fixture must pass. Without that pair, the failing assertion proves nothing.
+- An unknown slug and an unpublished slug must return **byte-identical**
+  responses. Two 404s with different copy would still leak.
+- Every release-validation rule is asserted in **both** directions: it fires
+  against content that violates it, and stays quiet against real content. Only
+  the second half would leave a broken rule and a satisfied rule looking
+  identical.
+
+Release validation failed for the whole of development, which is what made
+building against placeholder content safe. It passes now, so each rule is
+exercised against a deliberately violating fixture instead.
 
 ---
 
@@ -171,8 +180,15 @@ branches, merges by squash after review, and deploys automatically. Deployment
 success is not acceptance — production is verified manually against
 [`docs/release-checklist.md`](docs/release-checklist.md).
 
-The release audit workflow is manual and expected to fail during development,
-because release validation refuses placeholder content.
+`production` is protected by a branch ruleset with no bypass actors, so it
+applies to the repository owner too: pull request required, squash merge only,
+both checks green, linear history, force pushes and deletions blocked.
+
+The release audit workflow is manual rather than automatic, because running the
+full gate on every push would be slow without being more informative. Running it
+end to end for the first time is what surfaced four defects — including a script
+declared in `package.json` that had never been written, and a workflow that had
+never once been dispatched.
 
 ---
 
@@ -207,6 +223,8 @@ Raw AI session exports are never published.
 | -------------------------------------------------------- | ------------------------------------------------------ |
 | [`docs/architecture.md`](docs/architecture.md)           | How the system is built and why                        |
 | [`docs/release-checklist.md`](docs/release-checklist.md) | The ordered gate before going public                   |
+| [`docs/release-audit.md`](docs/release-audit.md)         | Dated audits: what was found, decided, and deferred    |
+| [`docs/content-authoring.md`](docs/content-authoring.md) | How to write and publish content truthfully            |
 | [`docs/product/`](docs/product/)                         | PRD, acceptance criteria, UX/UI spec, technical design |
 | [`docs/governance/`](docs/governance/)                   | Git workflow and GitHub configuration                  |
 | [`docs/plans/`](docs/plans/)                             | Implementation plan                                    |


### PR DESCRIPTION
## Purpose

The README described a **pre-launch state in five places** while the site was deployed and indexed. This repository is public — anyone who visited the live portfolio and then opened it read that the portfolio was not deployed.

This is v1.1 **Issue 1 / AC-01**, brought forward. A false statement about deployment sitting in public is worth an hour rather than a release cycle.

## Corrected

| Was | Now |
|---|---|
| `not yet deployed. Vercel connection is pending.` | The live URL |
| `implementation in progress` … `renders as chrome only` | Production, verified against the release checklist rather than inferred from a build |
| `Hosting \| Vercel (planned)` | `Vercel, deployed from production` |
| `Launch gate — expected to fail until content is final` | What the gate actually checks |
| `release audit … expected to fail during development` | Why the workflow is manual, and what running it first found |

## Two more had quietly become false

Neither was on the original list. I found them by re-reading the whole file rather than fixing only what was flagged.

**The testing section** claimed release validation *must fail* on Draft content. That was the safety property during development and is no longer how those tests work — each rule is now asserted in **both** directions: firing against a violating fixture, staying quiet against real content.

**The CI section** claimed the release audit workflow is expected to fail. It now explains why the workflow is manual, and what running it end to end for the first time actually surfaced — including a script declared in `package.json` that had never been written.

The branch ruleset is now described too, since it is enforcement rather than policy and applies to the repository owner as well.

## Deliberately not changed

The opening line still reads **"backend-focused full-stack developer"**.

Repositioning to Backend Developer is v1.1 **Issue 2**, and it touches `profile.ts`, `site.ts`, and public metadata together. Changing it here alone would leave the README disagreeing with the live site — which is precisely the class of problem this commit exists to remove.

## Verified, not assumed

- All **eight** relative documentation links resolve
- The live URL returns **200**
- `npm run check` — exit 0, 397 tests

Two documents that existed but were missing from the documentation table are now listed: `release-audit.md` and `content-authoring.md`.

## Changed areas

`README.md` — 31 insertions, 13 deletions. Documentation only.

## Known limitations

AC-01 is satisfied; the remaining v1.1 acceptance criteria are untouched and belong to that release.

## Deployment impact

None. The README is not rendered by the site.

## Rollback notes

`git revert` restores the pre-launch wording — which would put a false deployment claim back in a public repository.

## Confidentiality review

Pass. Public URL and public repository facts only.

## FAC/NFAC references

NFAC-CONTENT-002, NFAC-MAINT-004
