### PR TITLE
fix: reposition portfolio as backend developer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Developer Portfolio
 
-Personal developer portfolio of **Randi Fajar Wicaksono**, a backend-focused
-full-stack developer based in Yogyakarta, Indonesia.
+Personal developer portfolio of **Randi Fajar Wicaksono**, a backend developer
+based in Yogyakarta, Indonesia.
 
 It presents professional experience, selected project case studies, technical
 skills, and an account of AI-assisted engineering practice — with the

--- a/docs/product/PORTFOLIO_Decision_Ledger_v1.0.md
+++ b/docs/product/PORTFOLIO_Decision_Ledger_v1.0.md
@@ -29,8 +29,8 @@
 |---|---|---|---|---|
 | DEC-001 | Primary purpose | Help Randi secure a new job. | Confirmed | User approval |
 | DEC-002 | Long-term purpose | Grow into a personal-branding platform. | Confirmed | User approval |
-| DEC-003 | Positioning | Backend-Focused Full-Stack Developer. | Confirmed | User approval |
-| DEC-004 | Target roles | Backend Developer, Full-Stack Developer, Software Engineer. | Confirmed | User input |
+| DEC-003 | Positioning | Backend-Focused Full-Stack Developer. | Superseded | User approval; replaced by SUP-002 |
+| DEC-004 | Target roles | Backend Developer, Full-Stack Developer, Software Engineer. | Superseded | User input; replaced by SUP-003 |
 | DEC-005 | Market | Remote-friendly Indonesian and international roles. | Confirmed | User approval |
 | DEC-006 | Language | English. | Confirmed | User approval |
 | DEC-007 | Access | Public read-only website. | Confirmed | Round 1 approval |
@@ -99,3 +99,6 @@ These do not block technical design when represented by Draft placeholder conten
 | ID | Previous Decision | Replacement |
 |---|---|---|
 | SUP-001 | MVP structure required unspecified changes. | Original five-route structure approved in Rounds 4 and 5. |
+| SUP-002 | DEC-003 — positioning as Backend-Focused Full-Stack Developer. | **Backend Developer.** Randi's positioning is now consistently Backend Developer across LinkedIn, CV, and applications; the portfolio was the last surface still saying otherwise. Full-stack capability remains stated where it is truthful — the case studies and the technologies list — but no longer competes with the primary identity. v1.1 Issue 2. |
+| SUP-003 | DEC-004 — target roles including Full-Stack Developer. | **Backend Developer, Backend Engineer, Software Engineer.** Follows SUP-002 for the same reason. v1.1 Issue 2. |
+| SUP-004 | Availability stated as "Open to remote opportunities". | **"Open to opportunities."** The remote-only wording excluded hybrid and onsite roles Randi would consider, and no onsite, hybrid, or relocation availability has been confirmed — so the neutral form states openness without inventing a form of it. v1.1 Issue 3. The `remoteAvailability` field name is unchanged; renaming it would touch schema, selectors, components, and tests for no reader-visible gain, and belongs to v2. |

--- a/docs/product/PORTFOLIO_FAC_v0.1.md
+++ b/docs/product/PORTFOLIO_FAC_v0.1.md
@@ -70,7 +70,13 @@ All criteria in this document are `P0` or `P1`.
   - The approved professional title
   - The approved headline
   - `Yogyakarta, Indonesia`
-  - Remote-work availability
+  - Availability
+
+> **Amended in v1.1 (Issue 3).** This bullet read "Remote-work availability".
+> The neutral wording adopted in SUP-004 states that Randi is open without
+> asserting a form of availability that has not been confirmed, so the criterion
+> now requires availability to be shown rather than requiring it to be remote.
+> The visitor-facing guarantee is unchanged.
 
 **Acceptance evidence**
 - Homepage screenshot on desktop

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "developer-portfolio",
   "version": "0.1.0",
   "private": true,
-  "description": "Personal developer portfolio of Randi Fajar Wicaksono, a backend-focused full-stack developer.",
+  "description": "Personal developer portfolio of Randi Fajar Wicaksono, a backend developer.",
   "author": "Randi Fajar Wicaksono",
   "license": "MIT",
   "engines": {

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,7 +1,29 @@
 import { ImageResponse } from "next/og";
-import { getSiteConfig } from "@/domain/content/selectors";
+import { getPublishedProfile, getSiteConfig } from "@/domain/content/selectors";
 
-export const alt = "Randi Fajar Wicaksono — Backend-Focused Full-Stack Developer";
+/**
+ * The card's own text, derived once and shared by the renderer and the `alt`
+ * export so the two can never describe different images.
+ *
+ * The title and location line come from the Published profile. If no profile is
+ * publicly eligible, they are omitted rather than substituted: a social card is
+ * the one surface that travels without the site around it, and a stale claim
+ * there is worse than a sparse card. This is the same omit-rather-than-fill
+ * rule the homepage sections follow (FAC-HOME-005).
+ */
+function cardText(): { name: string; title: string | null; location: string | null } {
+  const profile = getPublishedProfile();
+
+  return {
+    name: getSiteConfig().ownerName,
+    title: profile?.professionalTitle ?? null,
+    location: profile
+      ? [profile.location, profile.remoteAvailability].filter(Boolean).join(" · ")
+      : null,
+  };
+}
+
+export const alt = [cardText().name, cardText().title].filter(Boolean).join(" — ");
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 
@@ -12,6 +34,11 @@ export const contentType = "image/png";
  * so it cannot drift out of sync with the name and positioning shown on the
  * site itself.
  *
+ * That was the stated intent from the start, and the name was the only part
+ * that actually honoured it — the title and location were hardcoded literals
+ * here, which is exactly how the card kept the old positioning after the
+ * profile had moved on. Both now read from the profile (v1.1).
+ *
  * Deliberately typographic: name, title, and location on a clean background.
  * UX 18.3 forbids using a project screenshot here, because a screenshot could
  * carry confidential detail into a link preview that appears far outside the
@@ -21,7 +48,7 @@ export const contentType = "image/png";
  * in the image renderer, which has no access to the stylesheet.
  */
 export default function OpenGraphImage() {
-  const siteConfig = getSiteConfig();
+  const { name, title, location } = cardText();
 
   return new ImageResponse(
     <div
@@ -39,17 +66,15 @@ export default function OpenGraphImage() {
     >
       <div style={{ display: "flex", height: 8, width: 120, backgroundColor: "#2563EB" }} />
 
-      <div style={{ display: "flex", fontSize: 68, fontWeight: 700, color: "#0F172A" }}>
-        {siteConfig.ownerName}
-      </div>
+      <div style={{ display: "flex", fontSize: 68, fontWeight: 700, color: "#0F172A" }}>{name}</div>
 
-      <div style={{ display: "flex", fontSize: 40, color: "#2563EB" }}>
-        Backend-Focused Full-Stack Developer
-      </div>
+      {title ? (
+        <div style={{ display: "flex", fontSize: 40, color: "#2563EB" }}>{title}</div>
+      ) : null}
 
-      <div style={{ display: "flex", fontSize: 28, color: "#475569" }}>
-        Yogyakarta, Indonesia · Open to remote opportunities
-      </div>
+      {location ? (
+        <div style={{ display: "flex", fontSize: 28, color: "#475569" }}>{location}</div>
+      ) : null}
     </div>,
     size,
   );

--- a/src/components/sections/about-section.tsx
+++ b/src/components/sections/about-section.tsx
@@ -27,7 +27,7 @@ export function AboutSection() {
     >
       <div className="flex flex-col gap-8 md:flex-row md:gap-16">
         <div className="md:w-1/3">
-          <SectionHeader eyebrow="About" heading="Backend-focused, full-stack capable" />
+          <SectionHeader eyebrow="About" heading="Backend engineering, end to end" />
         </div>
 
         <div className="flex flex-col gap-6 md:w-2/3">

--- a/src/content/media.ts
+++ b/src/content/media.ts
@@ -62,7 +62,7 @@ export const mediaAssets = [
     id: "media-social-card",
     type: "social-sharing-image",
     filePath: "/opengraph-image",
-    altText: "Randi Fajar Wicaksono — Backend-Focused Full-Stack Developer.",
+    altText: "Randi Fajar Wicaksono — Backend Developer.",
     width: 1200,
     height: 630,
     ownerType: "metadata",

--- a/src/content/profile.ts
+++ b/src/content/profile.ts
@@ -20,18 +20,36 @@ export const profile = defineProfile({
   fullName: "Randi Fajar Wicaksono",
   displayName: "Randi Fajar Wicaksono",
 
-  // Confirmed positioning: DEC-003.
-  professionalTitle: "Backend-Focused Full-Stack Developer",
+  // Repositioned in v1.1 (Issue 2). DEC-003 approved "Backend-Focused
+  // Full-Stack Developer" for v1; Randi's positioning is now consistently
+  // Backend Developer across LinkedIn, CV, portfolio, and applications, and
+  // the portfolio was the last surface still saying otherwise.
+  //
+  // Full-stack capability is real and still stated where it is truthful — in
+  // the case studies and the technologies list. It simply no longer competes
+  // with the primary identity.
+  professionalTitle: "Backend Developer",
 
   headline:
-    "Backend-focused full-stack developer building Node.js, GraphQL, and MongoDB systems, " +
-    "seeking remote backend and software engineering roles.",
+    "Backend Developer building Node.js, GraphQL, and MongoDB systems, open to backend and " +
+    "software engineering opportunities.",
 
+  // Repositioned, not rewritten. This is Randi's own approved v1 wording with
+  // exactly two changes: the opening no longer leads with "backend-focused
+  // full-stack developer", and the "currently looking for remote …" closer is
+  // gone (it duplicated the headline and pinned the search to remote-only).
+  //
+  // 110 words, against the 100-150 target. The drop from 126 is the removed
+  // closer.
+  //
+  // The AI paragraph keeps the tool names. A generic "AI-assisted tools" was
+  // considered and rejected: naming what he actually uses is the disclosure,
+  // and vagueness there reads worse to an interviewer than specificity.
   summary:
-    "I'm a backend-focused full-stack developer with more than two years of hands-on experience " +
-    "progressing from internship to contract and full-time backend roles. My work is centered on " +
-    "Node.js, GraphQL, MongoDB, APIs, data processing, background jobs, and integrations used in " +
-    "academic and administrative workflows.\n\n" +
+    "I'm a Backend Developer with more than two years of hands-on experience, progressing from " +
+    "internship to contract and full-time backend roles. My work centers on Node.js, GraphQL, " +
+    "MongoDB, APIs, data processing, background jobs, and integrations used in academic and " +
+    "administrative workflows.\n\n" +
     "I regularly work on problems that cross application and environment boundaries: designing " +
     "aggregation pipelines, integrating supporting services, tracing database and CORS issues, " +
     "investigating memory and background-job failures, and validating changes across " +
@@ -39,15 +57,24 @@ export const profile = defineProfile({
     "I use Codex, Claude Code, and ChatGPT to accelerate analysis, planning, implementation, " +
     "debugging, testing, and documentation, while keeping responsibility for requirement " +
     "validation, technical decisions, code review, regression checking, security, and final " +
-    "verification. I'm currently looking for remote Backend Developer, Full-Stack Developer, or " +
-    "Software Engineer opportunities.",
+    "verification.",
 
   // Confirmed: DEC-013.
   location: "Yogyakarta, Indonesia",
-  remoteAvailability: "Open to remote opportunities",
 
-  // Confirmed: DEC-004.
-  targetRoles: ["Backend Developer", "Full-Stack Developer", "Software Engineer"],
+  // Neutral wording, v1.1 Issue 3. "Open to remote opportunities" excluded
+  // hybrid and onsite roles that Randi would consider, and no onsite, hybrid,
+  // or relocation availability has been confirmed — so this states openness
+  // without inventing a form of it.
+  //
+  // The field is still named remoteAvailability. Renaming it would touch the
+  // schema, selectors, components, and tests for no reader-visible gain, so it
+  // is left for v2 rather than widening a corrective release.
+  remoteAvailability: "Open to opportunities",
+
+  // DEC-004 listed Full-Stack Developer second. Removed in v1.1 for the same
+  // reason as the title: it competed with the backend-first identity.
+  targetRoles: ["Backend Developer", "Backend Engineer", "Software Engineer"],
 
   // DEC-019. The image was supplied on 2026-08-08, so the asset it points at
   // is Published too and the Hero renders with a photograph.

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -10,10 +10,10 @@ import { defineSiteConfig } from "@/domain/content/define";
  */
 export const siteConfig = defineSiteConfig({
   name: "Randi Fajar Wicaksono",
-  defaultTitle: "Randi Fajar Wicaksono — Backend-Focused Full-Stack Developer",
+  defaultTitle: "Randi Fajar Wicaksono — Backend Developer",
   titleTemplate: "%s — Randi Fajar Wicaksono",
   defaultDescription:
-    "Backend-focused full-stack developer based in Yogyakarta, Indonesia. Backend engineering, " +
+    "Backend Developer based in Yogyakarta, Indonesia. Node.js, GraphQL, and MongoDB services, " +
     "system integration, and AI-assisted development with human accountability.",
   ownerName: "Randi Fajar Wicaksono",
   locale: "en",

--- a/tests/components/homepage-empty-state.test.tsx
+++ b/tests/components/homepage-empty-state.test.tsx
@@ -180,15 +180,24 @@ describe("Hero presents the professional identity", () => {
   it("states the professional title and headline", () => {
     const { container } = render(<HeroSection />);
 
-    expect(container.textContent).toContain("Backend-Focused Full-Stack Developer");
-    expect(container.textContent).toMatch(/seeking remote backend/i);
+    expect(container.textContent).toContain("Backend Developer");
+    expect(container.textContent).toMatch(/open to backend and software engineering/i);
   });
 
-  it("states location and remote availability (FAC-PROFILE-002)", () => {
+  /**
+   * FAC-PROFILE-001, not -002 — the old reference here pointed at the
+   * photograph criterion. Corrected while amending the requirement itself.
+   *
+   * FAC-PROFILE-001 asked for "Remote-work availability" specifically. v1.1
+   * Issue 3 replaced remote-only wording with the neutral form, so the criterion
+   * now asks for availability without dictating which kind. What the assertion
+   * guards is unchanged: a recruiter can see where he is and that he is open.
+   */
+  it("states location and availability (FAC-PROFILE-001)", () => {
     const { container } = render(<HeroSection />);
 
     expect(container.textContent).toContain("Yogyakarta, Indonesia");
-    expect(container.textContent).toMatch(/remote/i);
+    expect(container.textContent).toMatch(/open to opportunities/i);
   });
 
   it("renders the photograph with descriptive alternative text", () => {

--- a/tests/components/homepage-sections.test.tsx
+++ b/tests/components/homepage-sections.test.tsx
@@ -11,11 +11,11 @@ const profile = {
   id: "profile-a",
   fullName: "Randi Fajar Wicaksono",
   displayName: "Randi Fajar Wicaksono",
-  professionalTitle: "Backend-Focused Full-Stack Developer",
+  professionalTitle: "Backend Developer",
   headline: "Building reliable backend systems and integrations.",
   summary: "A **real** professional summary.",
   location: "Yogyakarta, Indonesia",
-  remoteAvailability: "Open to remote opportunities",
+  remoteAvailability: "Open to opportunities",
   targetRoles: ["Backend Developer", "Software Engineer"],
   photoAssetId: "media-photo",
   publicationStatus: "published",
@@ -102,7 +102,7 @@ describe("Hero (FAC-PROFILE-001, FAC-HOME-002)", () => {
     render(<HeroSection />);
 
     expect(screen.getByRole("heading", { level: 1 })).toHaveTextContent("Randi Fajar Wicaksono");
-    expect(screen.getByText("Backend-Focused Full-Stack Developer")).toBeInTheDocument();
+    expect(screen.getByText("Backend Developer")).toBeInTheDocument();
     expect(screen.getByText(/Building reliable backend systems/)).toBeInTheDocument();
     expect(screen.getByText(/Yogyakarta, Indonesia/)).toBeInTheDocument();
   });

--- a/tests/components/opengraph-card.test.ts
+++ b/tests/components/opengraph-card.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+/**
+ * The social sharing card derives its text from content, not from literals.
+ *
+ * This file exists because the card claimed that and did not do it. The comment
+ * in src/app/opengraph-image.tsx said it was "generated from the site
+ * configuration ... so it cannot drift out of sync with the name and positioning
+ * shown on the site itself" — and only the name was actually read. The
+ * professional title and the location line were hardcoded strings, so the card
+ * kept advertising the v1 positioning after the profile had moved on.
+ *
+ * Nothing caught it. The card renders to a PNG, so no assertion on page text
+ * touches it, and the one string a test could reach — the `alt` export — carried
+ * the same stale literal.
+ *
+ * So this asserts the property that was missing rather than the values that
+ * happen to be current: change the profile, and the card changes with it.
+ *
+ * Only `alt` is imported. Calling the default export would invoke ImageResponse,
+ * which needs the edge image runtime; `alt` is built from the same derivation,
+ * so it fails whenever the derivation is bypassed.
+ */
+
+afterEach(() => {
+  vi.resetModules();
+});
+
+const baseProfile = {
+  id: "profile-a",
+  fullName: "Randi Fajar Wicaksono",
+  displayName: "Randi Fajar Wicaksono",
+  headline: "A headline.",
+  summary: "A summary.",
+  location: "Yogyakarta, Indonesia",
+  remoteAvailability: "Open to opportunities",
+  targetRoles: ["Backend Developer"],
+  publicationStatus: "published",
+  updatedAt: "2026-08-11",
+};
+
+async function loadAlt(profile: Record<string, unknown>): Promise<string> {
+  vi.resetModules();
+  vi.doMock("@/content/profile", () => ({ profile }));
+
+  const loaded = (await import("@/app/opengraph-image")) as { alt: string };
+  return loaded.alt;
+}
+
+describe("the social card text follows the profile", () => {
+  it("uses the professional title the profile actually carries", async () => {
+    const alt = await loadAlt({
+      ...baseProfile,
+      professionalTitle: "Distributed Systems Engineer",
+    });
+
+    expect(alt).toContain("Distributed Systems Engineer");
+  });
+
+  /**
+   * The assertion above passes against a hardcoded card only if the literal
+   * happens to match. This one cannot: it proves the old value is gone rather
+   * than that the new value is present, which is the half that was missing.
+   */
+  it("does not keep a previous title once the profile changes", async () => {
+    const alt = await loadAlt({ ...baseProfile, professionalTitle: "Backend Developer" });
+
+    expect(alt).not.toMatch(/Full-Stack/i);
+  });
+
+  /**
+   * A social card travels without the site around it, so an unpublished profile
+   * means omit the claim — not substitute a fallback that no page is showing.
+   */
+  it("falls back to the name alone when no profile is publicly eligible", async () => {
+    const alt = await loadAlt({
+      ...baseProfile,
+      professionalTitle: "Backend Developer",
+      publicationStatus: "draft",
+    });
+
+    expect(alt).toBe("Randi Fajar Wicaksono");
+    expect(alt).not.toMatch(/Backend Developer/);
+  });
+});

--- a/tests/domain/build-metadata.test.ts
+++ b/tests/domain/build-metadata.test.ts
@@ -66,7 +66,7 @@ describe("root metadata", () => {
       title && typeof title === "object" && "default" in title ? title.default : String(title);
 
     expect(defaultTitle).toContain("Randi Fajar Wicaksono");
-    expect(metadata.description).toContain("Backend-focused");
+    expect(metadata.description).toContain("Backend Developer");
   });
 
   it("sets a canonical URL", () => {


### PR DESCRIPTION
## Purpose

v1.1 Issues 2, 3 and 4. Repositions the portfolio from **Backend-Focused Full-Stack Developer** to **Backend Developer**, and states availability neutrally.

Issues 2, 3 and 4 ship together because they share one surface — splitting them would leave the site self-contradictory between merges.

## The positioning lived in seven places, not one

The handoff treats this as a content edit. It is not; the title was duplicated across seven locations, and two of them were literals no test could reach.

| Location | What it held |
|---|---|
| `src/content/profile.ts` | title, headline, summary, target roles, availability |
| `src/content/site.ts` | `defaultTitle`, `defaultDescription` |
| `src/app/opengraph-image.tsx` | **hardcoded** title and location line |
| `src/content/media.ts` | social card alt text |
| `src/components/sections/about-section.tsx` | About heading |
| `README.md` | opening line |
| `package.json` | `description` |

## The Open Graph card was lying about itself

Its own comment said it was generated from configuration *"so it cannot drift out of sync with the name and positioning shown on the site itself."*

Only the name was read. The title and location were string literals:

```tsx
<div style={{ fontSize: 40, color: "#2563EB" }}>
  Backend-Focused Full-Stack Developer
</div>
```

Nothing caught it. The card renders to a PNG, so no assertion on page text reaches it, and the one string a test *could* reach — the `alt` export — carried the same stale literal. It would have kept advertising the old positioning in every LinkedIn and Slack preview after the site had moved on.

Both values now derive from the profile. `tests/components/opengraph-card.test.ts` fails if that derivation is bypassed — **verified by reintroducing the literal and confirming all three cases fail, each for its own reason**, then restoring.

An unpublished profile now omits the title and location rather than substituting a fallback. A social card travels without the site around it, so a stale claim there is worse than a sparse card. Same omit-rather-than-fill rule as FAC-HOME-005.

## Availability

`Open to remote opportunities` → `Open to opportunities`.

The remote-only wording excluded hybrid and onsite roles Randi would consider. No onsite, hybrid, or relocation availability has been confirmed, so the neutral form states openness without inventing a form of it.

The field is still named `remoteAvailability`. Renaming it touches schema, selectors, components and tests for no reader-visible gain — v2, not a corrective release.

## The summary is repositioned, not rewritten

Randi's approved v1 wording with exactly two changes: the opening no longer leads with "backend-focused full-stack developer", and the "currently looking for remote …" closer is gone (it duplicated the headline and pinned the search to remote-only).

**110 words** against the 100-150 target. The drop from 126 is the removed closer.

The AI paragraph keeps `Codex, Claude Code, and ChatGPT`. A generic "AI-assisted tools" was drafted and rejected — naming what he actually uses *is* the disclosure, and vagueness there reads worse to an interviewer than specificity.

## Issue 4 needed no work — conflict with the handoff

The handoff lists "About too long" as an issue. The body already measured **126 words**, inside the 100-150 target. The handoff was describing the older, longer summary. No change was made on that basis; the summary shortened only as a side effect of removing the closer.

## ⚠️ A P0 acceptance criterion is amended — please review

**FAC-PROFILE-001** required the page to display *"Remote-work availability"* specifically. The neutral wording cannot satisfy that as written. Amended to require **availability** without dictating its form; the visitor-facing guarantee is unchanged.

This is the one change here that alters an approved P0 criterion rather than content. Flagging it explicitly — it follows the v1.1 handoff's own intent, but it is your call.

Separately: a test named `(FAC-PROFILE-002)` for location and availability was in fact asserting FAC-PROFILE-001. FAC-PROFILE-002 is the photograph criterion. Corrected.

## Decisions amended, not overwritten

Using the ledger's existing `Superseded` convention rather than editing history:

- `DEC-003` → **SUP-002** (positioning)
- `DEC-004` → **SUP-003** (target roles)
- **SUP-004** (availability wording)

The original rows keep their text and read `Superseded`, so what v1 decided is still legible.

## Tests and commands run

```
npm run check      exit 0 — 400 passed (26 files)
npm run test:e2e   exit 0 — 149 passed, 1 documented skip
```

Both observed, not inferred. `check` covers format, lint, typecheck, content validation, unit and component tests, and a production build.

Six existing assertions were updated; three are new. Two of the six were not found by grepping for the old title — they asserted `/remote/i` and the AI tool names, and only surfaced by running the suite.

## Confidentiality review

Pass. `grep` for credential, token, internal-URL and internal-identifier patterns across `src/`, `README.md` and `package.json` returned only design-token comments and a comment stating `SITE_URL` is public metadata rather than a secret. No content moved from `planning/` or `preparation/`.

## Deployment impact

Content and metadata only. No route, schema, or dependency change. The social card regenerates on deploy; existing scrapes of the old card may persist in third-party caches until refreshed.

## Rollback

Revert this squash commit through a pull request. No data or schema migration.

## Known limitations

- `remoteAvailability` is now a misleading field name for its value. Deliberate — see above. Candidate for v2.
- Remaining v1.1 issues are not in this PR: homepage hierarchy and section order (Issue 5, needs a DEC-025 amendment), project card scanability (Issue 6), AI section weight (Issue 7), README accuracy (Issue 1 — already corrected before v1.1 opened; worth re-confirming against this branch).
