### PR TITLE
feat: add motion tokens and close three accessibility gaps

### DIFF
--- a/docs/product/PORTFOLIO_UX_UI_SPEC_v2.0.md
+++ b/docs/product/PORTFOLIO_UX_UI_SPEC_v2.0.md
@@ -193,7 +193,13 @@ so they resolve from a project detail page.
 ### UX2 5.1 — No active-section indicator
 
 PRD §24.2 is **deliberately not delivered**. It requires either a second Client
-Component or a CSS scroll-timeline that silently does nothing in Firefox and WebKit.
+Component or a CSS scroll-timeline that silently does nothing in Firefox.
+
+> **Correction (Phase 2c).** This previously said "Firefox and WebKit". Measured
+> across all three engines: Chromium and **WebKit both support**
+> `animation-timeline`; only Firefox does not. The deferral decision is
+> unchanged — one major engine without the feature is still a silent gap for a
+> large share of visitors — but the stated reason was wrong by one browser.
 `MobileNavigation` remains the only `"use client"` file — a property Randi has
 published in his live case study.
 

--- a/docs/product/PORTFOLIO_V2_ANALYSIS.md
+++ b/docs/product/PORTFOLIO_V2_ANALYSIS.md
@@ -448,8 +448,13 @@ functions, no content coupling, following the existing
 The single-Client-Component property is preserved. **Decision taken:** §24.2's
 active-section indicator is deliberately deferred rather than delivered, because it
 would require either a second client component or a Chromium-only CSS scroll-timeline
-that silently does nothing in Firefox and WebKit. Recorded as a deferral with its
+that silently does nothing in Firefox. Recorded as a deferral with its
 reason, not dropped silently.
+
+> **Corrected in Phase 2c.** This said "Firefox and WebKit". Measured across all
+> three engines: Chromium and WebKit both support `animation-timeline`; only
+> Firefox does not. The decision stands — a feature missing in one major engine
+> is still a silent gap — but the reason as written overstated it.
 
 ---
 

--- a/e2e/accessibility.spec.ts
+++ b/e2e/accessibility.spec.ts
@@ -1,6 +1,9 @@
 import AxeBuilder from "@axe-core/playwright";
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
+import { projects } from "../src/content/projects";
+
+const publishedProjects = projects.filter((project) => project.publicationStatus === "published");
 
 /**
  * Automated accessibility scanning (TD 15.4, NFAC-A11Y-001).
@@ -66,9 +69,30 @@ async function blockingViolations(page: Page): Promise<string[]> {
     );
 }
 
+/**
+ * Project Detail is derived rather than hardcoded so the scan follows the
+ * published set instead of a slug that could quietly stop existing.
+ *
+ * `publishedProjects` reads the registry directly, which is deliberate here:
+ * end-to-end specs sit outside the lint boundary precisely so a privacy test is
+ * not circular. Falling back to the index route rather than throwing keeps the
+ * suite meaningful in the empty-content state the project supports.
+ */
+const [firstPublished] = publishedProjects;
+
 const PAGE_TYPES = [
   { name: "Home", path: "/" },
   { name: "Projects Index", path: "/projects" },
+  {
+    /*
+     * Added in v2. Before this, the project detail route was scanned by
+     * nothing at all — and it is both the longest page on the site and the one
+     * receiving the largest redesign (PRD 33). The gap predates v2; it is fixed
+     * here because this is the phase that finishes the accessibility baseline.
+     */
+    name: "Project Detail",
+    path: firstPublished ? `/projects/${firstPublished.slug}` : "/projects",
+  },
   { name: "Not Found", path: "/this-route-does-not-exist" },
 ];
 

--- a/e2e/reduced-motion.spec.ts
+++ b/e2e/reduced-motion.spec.ts
@@ -1,0 +1,134 @@
+import { expect, test } from "@playwright/test";
+import { SECTION_IDS } from "../src/lib/constants";
+
+/**
+ * Reduced motion.
+ *
+ * PRD 62 lists reduced-motion tests among the things to *maintain*. There were
+ * none, so this file is the thing being maintained from now on.
+ *
+ * What it guards is not "does the animation stop" — that is easy and mostly
+ * self-evident. It guards the failure that actually loses information: an
+ * entrance effect whose resting state is invisible. With motion disabled such
+ * an element never animates, never becomes visible, and the content is simply
+ * absent for the user who asked for less motion.
+ *
+ * Playwright emulates the media query at the browser level, so this exercises
+ * the real cascade rather than a stubbed matchMedia.
+ */
+
+/*
+ * Set on the browser context rather than per page, so the preference is in
+ * effect for the very first paint. Emulating it after navigation would test a
+ * page that had already rendered with motion enabled.
+ */
+test.use({ contextOptions: { reducedMotion: "reduce" } });
+
+const HOMEPAGE_SECTIONS = [
+  SECTION_IDS.about,
+  SECTION_IDS.experience,
+  SECTION_IDS.projects,
+  SECTION_IDS.skills,
+  SECTION_IDS.aiWorkflow,
+  SECTION_IDS.contact,
+] as const;
+
+test("every homepage section is visible with motion disabled", async ({ page }) => {
+  await page.goto("/");
+
+  // The h1 is in the hero, which carries no id of its own.
+  await expect(page.locator("h1")).toBeVisible();
+
+  for (const id of HOMEPAGE_SECTIONS) {
+    await expect(
+      page.locator(`#${id}`),
+      `#${id} is not visible under reduced motion`,
+    ).toBeVisible();
+  }
+});
+
+test("no element is left transparent or displaced by a disabled animation", async ({ page }) => {
+  await page.goto("/");
+  await page.waitForLoadState("networkidle");
+
+  /*
+   * Scans every element that carries text, not just the ones known to animate.
+   * A future reveal added to any component is caught without this file needing
+   * to know about it.
+   *
+   * Zero-area elements are skipped: `sr-only` content is legitimately collapsed,
+   * and an empty wrapper is not a failure.
+   */
+  const hidden = await page.evaluate(() => {
+    const offenders: string[] = [];
+
+    for (const element of document.querySelectorAll<HTMLElement>("main *")) {
+      const text = element.textContent?.trim() ?? "";
+      if (text.length === 0) continue;
+
+      const box = element.getBoundingClientRect();
+      if (box.width === 0 || box.height === 0) continue;
+
+      const style = getComputedStyle(element);
+      if (style.visibility === "hidden" || style.display === "none") continue;
+
+      if (Number.parseFloat(style.opacity) < 0.99) {
+        offenders.push(
+          `${element.tagName.toLowerCase()} opacity ${style.opacity}: ${text.slice(0, 40)}`,
+        );
+      }
+    }
+
+    return offenders;
+  });
+
+  expect(hidden, `\nInvisible under reduced motion:\n${hidden.join("\n")}\n`).toEqual([]);
+});
+
+test("the reduced-motion rule disables scroll-driven timelines too", async ({ page }) => {
+  await page.goto("/");
+
+  /*
+   * The specific gap this closes: `animation-duration: 0.01ms` does nothing to
+   * `animation-timeline: view()`, which advances on scroll position rather than
+   * time. Without `animation-timeline: none` a scroll-driven reveal would run
+   * at full effect for a user who asked for less motion.
+   *
+   * Probes the cascade with a real element rather than reading the stylesheet,
+   * so it stays true regardless of how the rule is expressed.
+   *
+   * Engine support is checked first, and measured rather than assumed:
+   *
+   *   chromium  supports=true   computed "none"
+   *   webkit    supports=true   computed "none"
+   *   firefox   supports=false  computed undefined
+   *
+   * Where the feature does not exist a scroll-driven animation cannot run at
+   * all, so the preference cannot be ignored and there is nothing to assert.
+   * Skipping is honest; asserting "none" there would fail for a browser that is
+   * not at risk, and weakening the assertion to accommodate it would stop
+   * guarding the two engines that are.
+   */
+  const support = await page.evaluate(() => ({
+    supported: CSS.supports("animation-timeline", "view()"),
+    resolved: getComputedStyle(document.body).animationTimeline ?? null,
+  }));
+
+  test.skip(
+    !support.supported,
+    "This engine does not implement animation-timeline, so no scroll-driven animation can run.",
+  );
+
+  const timeline = await page.evaluate(() => {
+    const probe = document.createElement("div");
+    probe.style.animationTimeline = "view()";
+    probe.textContent = "probe";
+    document.body.append(probe);
+
+    const resolved = getComputedStyle(probe).animationTimeline;
+    probe.remove();
+    return resolved;
+  });
+
+  expect(timeline).toBe("none");
+});

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -145,6 +145,21 @@
   --radius-button: 0.5rem;
   --radius-card: 0.875rem;
   --radius-badge: 9999px;
+
+  /*
+   * Motion — UX2 7.
+   *
+   * Durations are tokens so reduced motion can neutralise them by value rather
+   * than only by a blanket override. See the reduced-motion block at the end of
+   * this file for why the blanket rule alone is not sufficient.
+   *
+   * Motion communicates state, hierarchy, interaction and navigation. Anything
+   * that exists purely for spectacle fails V2-DP-005.
+   */
+  --motion-fast: 120ms;
+  --motion-base: 200ms;
+  --motion-slow: 320ms;
+  --motion-ease: cubic-bezier(0.2, 0, 0.2, 1);
 }
 
 /*
@@ -301,16 +316,64 @@
 }
 
 /*
+ * Entrance effects, opt-in (UX2 7.2).
+ *
+ * Declared under no-preference and animating FROM a visible resting state.
+ *
+ * The direction matters. An element parked at opacity: 0 by default, revealed
+ * by an animation, simply never appears for a reduced-motion user — the
+ * information is gone, not merely still. PRD 23 requires the full information
+ * architecture to survive with motion off, so the base state is always the
+ * readable one and the animation only adds arrival.
+ */
+@media (prefers-reduced-motion: no-preference) {
+  .motion-rise {
+    animation: motion-rise var(--motion-slow) var(--motion-ease) both;
+  }
+
+  @keyframes motion-rise {
+    from {
+      opacity: 0;
+      transform: translateY(0.5rem);
+    }
+  }
+}
+
+/*
  * Reduced motion.
  *
- * NFAC-A11Y-006 requires every animation to be non-essential and to respect
- * the user's preference. Content access is never delayed by a transition, so
+ * NFAC-A11Y-006 requires every animation to be non-essential and to respect the
+ * user's preference. Content access is never delayed by a transition, so
  * removing them entirely is safe.
+ *
+ * Three overlapping mechanisms, and the middle one is the reason this block was
+ * rewritten:
+ *
+ *   1. Collapse the duration tokens, so anything built on them stops.
+ *
+ *   2. Disable scroll timelines. `animation-duration: 0.01ms` does NOTHING to
+ *      an animation driven by `animation-timeline: view()`, because that
+ *      advances on scroll progress rather than elapsed time. A section reveal
+ *      built that way would ignore the user's preference completely while
+ *      appearing to respect it — the v1 block could not have caught it.
+ *
+ *   3. The v1 blanket rule, kept as a backstop for anything that bypasses the
+ *      tokens entirely.
+ *
+ * Asserted by e2e/reduced-motion.spec.ts. PRD 62 asks for reduced-motion tests
+ * to be *maintained*; before v2 there were none to maintain.
  */
 @media (prefers-reduced-motion: reduce) {
+  :root {
+    --motion-fast: 1ms;
+    --motion-base: 1ms;
+    --motion-slow: 1ms;
+  }
+
   *,
   *::before,
   *::after {
+    animation-timeline: none !important;
     animation-duration: 0.01ms !important;
     animation-iteration-count: 1 !important;
     transition-duration: 0.01ms !important;

--- a/tests/design/typography.test.ts
+++ b/tests/design/typography.test.ts
@@ -7,8 +7,14 @@ import { describe, expect, it } from "vitest";
  * them.
  *
  * 1. A stray raw size utility. Tailwind silently generates nothing for a class
- *    it does not know, so a leftover `text-xl` after the migration produces no
- *    CSS and no error — the element just inherits, and it looks *almost* right.
+ *    it does not know, so one left behind by the migration produces no CSS and
+ *    no error — the element just inherits, and it looks *almost* right.
+ *
+ *    Note the prose here deliberately avoids spelling out the class names.
+ *    Tailwind v4 scans this file for class-like strings, and the first version
+ *    of this comment caused two dead utilities to be emitted into the shipped
+ *    stylesheet — generated from documentation, used by nothing. Harmless, but
+ *    a guard should not pollute the artifact it guards.
  *
  * 2. A clamp() without a rem term. A preferred value expressed purely in vw
  *    does not respond to browser zoom, so the text stays put while everything
@@ -29,7 +35,7 @@ function sourceFiles(dir: string): string[] {
 
 /**
  * Tailwind's built-in size scale. These are exactly the names the v2 scale
- * replaces — `text-meta` instead of `text-sm`, and so on.
+ * replaces, one role-named token per built-in step.
  *
  * Deliberately not matched with a leading `(sm|lg):` alternative, because a
  * responsive variant of a raw size is just as wrong and the pattern below


### PR DESCRIPTION
## Purpose

Phase 2c — the last of the design-system phases. Motion duration tokens, a reduced-motion rework, the **first reduced-motion tests this project has ever had**, and the project detail route finally added to the axe scan.

After this the design system is complete and Phase 3 begins adopting `data-surface` on real sections.

## The reduced-motion block could not do what it claimed

It set `animation-duration: 0.01ms`, which does **nothing** to an animation driven by `animation-timeline: view()` — that advances on scroll progress, not elapsed time. A scroll-driven reveal would have ignored the user's preference entirely *while appearing to respect it*.

**Proved, not argued.** Removing the new `animation-timeline: none` line:

```
Expected: "none"
Received: "view()"     ← chromium
Received: "view()"     ← webkit
2 failed, 4 passed
```

Without the rule, a scroll-driven animation runs at full effect for someone who asked for less motion.

## A correction to something I wrote earlier this release

Engine support was measured, not assumed:

```
chromium  supports=true   computed "none"
webkit    supports=true   computed "none"
firefox   supports=false  computed undefined
```

The specification and the analysis both said a CSS scroll-timeline *"silently does nothing in Firefox and WebKit"*. **WebKit supports it; only Firefox does not.** Both documents now say so.

The deferral decision for the active-section indicator (§24.2) is unchanged — one major engine without the feature is still a silent gap for a large share of visitors — but the reason as written overstated it by one browser.

**Firefox is skipped rather than asserted.** Where the feature doesn't exist a scroll-driven animation can't run, so there's nothing to guard. Weakening the assertion to accommodate Firefox would have stopped guarding the two engines that *are* at risk.

## Entrance effects animate from visible

Declared under `prefers-reduced-motion: no-preference`, animating **from** a visible resting state. An element parked at `opacity: 0` and revealed by an animation simply never appears for a reduced-motion user — the information is gone, not merely still. §23 requires the IA to survive with motion off.

A test now scans **every text-bearing element in `main`** for a resting opacity below 1, so a reveal added to any future component is caught without this file knowing about it.

## Project Detail joins the axe scan

It was scanned by **nothing at all**, while being the longest page on the site and the one receiving the largest redesign (§33). It passes on all three engines.

The slug is derived from the published set rather than hardcoded, so the scan follows content instead of a string that could quietly stop existing.

## Dead CSS from the last release, fixed

The typography guard's own prose caused Tailwind to emit two dead utilities into the shipped stylesheet — generated from documentation, used by nothing. Reworded rather than excluding `tests/` from content detection: excluding a directory is the kind of change that quietly stops catching things later.

## Tests and commands run

```
npm run check      exit 0 — 424 passed (30 files)
npm run test:e2e   exit 0 — 160 passed, 2 skipped
```

Both observed. E2E went 149→160 passing: +9 reduced-motion (3 tests × 3 engines, less the honest Firefox skip) and +3 Project Detail axe scans. The second skip is that Firefox case; the first remains the documented WebKit skip-link default.

## Confidentiality review

Pass. No content changes. Files staged by explicit path; `V2_HANDOFF_PRD.md` remains untracked and was confirmed unstaged before committing.

## Deployment impact

No visible change. Motion tokens are declared but nothing consumes them yet, and the `.motion-rise` class has no call sites — both land here so Phase 3 can use them without carrying their risk.

## Rollback

Revert this squash commit through a pull request.

## Known limitations

- `.motion-rise` is unused until Phase 3. Declared with its guard first, deliberately.
- The opacity scan covers `main` only. Header and footer are excluded because the mobile drawer legitimately animates opacity while open, and asserting there would need state-aware logic for no real gain.
