### PR TITLE
fix: point the hero at experience and drop full-stack from contact

### DIFF
--- a/src/components/sections/contact-section.tsx
+++ b/src/components/sections/contact-section.tsx
@@ -39,7 +39,15 @@ export function ContactSection() {
           eyebrow="Get in touch"
           heading="Contact"
           id={SECTION_IDS.contact}
-          description="Open to backend, full-stack, and software engineering roles. The fastest way to reach me is email."
+          /*
+           * V2-P0-001. This offered "backend, full-stack, and software
+           * engineering roles", which contradicted SUP-002 — v1.1 removed
+           * Full-Stack Developer as a target role, and this line was the last
+           * place still offering it.
+           *
+           * Wording is Randi's decision, taken from the PRD proposal.
+           */
+          description="Open to backend and software engineering opportunities. The fastest way to reach me is email."
         />
 
         <div className="flex flex-wrap items-center gap-3">

--- a/src/components/sections/hero-section.tsx
+++ b/src/components/sections/hero-section.tsx
@@ -5,7 +5,7 @@ import {
   getPublishedMediaAsset,
   getPublishedProfile,
 } from "@/domain/content/selectors";
-import { ROUTES } from "@/lib/constants";
+import { ROUTES, SECTION_IDS } from "@/lib/constants";
 
 /**
  * The Hero (UX 7.3).
@@ -47,7 +47,19 @@ export function HeroSection() {
           </p>
 
           <div className="mt-2 flex flex-wrap items-center gap-3">
-            <ButtonLink href={ROUTES.projects}>View Projects</ButtonLink>
+            {/*
+             * V2-P0-002. The primary action was "View Projects", which pointed
+             * away from the section the homepage now leads with: SUP-005 put
+             * Work Experience ahead of Selected Projects, and the hero was
+             * still sending the first click past it.
+             *
+             * It targets the Experience anchor rather than a route, because
+             * that is where the evidence is. Wording is Randi's decision, taken
+             * from the PRD proposal.
+             */}
+            <ButtonLink href={`${ROUTES.home}#${SECTION_IDS.experience}`}>
+              View Experience
+            </ButtonLink>
 
             {/* FAC-HOME-002: the Resume action appears only when one exists. */}
             {resume ? (

--- a/tests/components/homepage-empty-state.test.tsx
+++ b/tests/components/homepage-empty-state.test.tsx
@@ -211,10 +211,12 @@ describe("Hero presents the professional identity", () => {
     expect(image.getAttribute("alt")).not.toMatch(/^(image|photo|picture)\b/i);
   });
 
+  // V2-P0-002: the primary action leads into Work Experience, which is the
+  // section SUP-005 put first.
   it("offers the primary action into the work", () => {
     render(<HeroSection />);
 
-    expect(screen.getByRole("link", { name: /view projects/i })).toBeVisible();
+    expect(screen.getByRole("link", { name: /view experience/i })).toBeVisible();
   });
 
   it("leaks no draft marker", () => {

--- a/tests/components/homepage-sections.test.tsx
+++ b/tests/components/homepage-sections.test.tsx
@@ -111,10 +111,21 @@ describe("Hero (FAC-PROFILE-001, FAC-HOME-002)", () => {
     expect(screen.getByText(/Yogyakarta, Indonesia/)).toBeInTheDocument();
   });
 
-  it("offers View Projects and the Resume action", () => {
+  /**
+   * The primary action points at Work Experience, not Projects (V2-P0-002).
+   *
+   * SUP-005 made Experience lead the homepage; the hero was still sending the
+   * first click past it. Asserting the destination as well as the label is what
+   * makes this a hierarchy test rather than a copy test — renaming the button
+   * without moving the target would still be wrong.
+   */
+  it("sends the primary action to Work Experience, with Resume secondary", () => {
     render(<HeroSection />);
 
-    expect(screen.getByRole("link", { name: "View Projects" })).toBeInTheDocument();
+    const primary = screen.getByRole("link", { name: "View Experience" });
+
+    expect(primary).toBeInTheDocument();
+    expect(primary).toHaveAttribute("href", "/#experience");
     expect(screen.getByRole("link", { name: /View Resume/ })).toBeInTheDocument();
   });
 


### PR DESCRIPTION
## Purpose

The two Phase 0 residuals from PRD §13. Wording for both is your decision, taken from the PRD's own proposals.

These belong to **Phase 0**, not Phase 3 — so they ship on their own branch from `production` rather than waiting behind the design-system work. They touch different files from #51, so the two are independent.

## V2-P0-002 — the hero pointed away from the lead section

The primary action was **"View Projects"**, sending the first click straight past the section the homepage now leads with. SUP-005 put Work Experience ahead of Selected Projects in v1.1; the hero never caught up.

```diff
- <ButtonLink href={ROUTES.projects}>View Projects</ButtonLink>
+ <ButtonLink href={`${ROUTES.home}#${SECTION_IDS.experience}`}>View Experience</ButtonLink>
```

The test asserts the **destination as well as the label**, which is what makes it a hierarchy test rather than a copy test. Verified by keeping the new label and reverting only the `href`:

```
× sends the primary action to Work Experience, with Resume secondary
  expect(element).toHaveAttribute("href", "/#experience")
```

A renamed button pointing at the wrong place still fails — which is the property worth having.

## V2-P0-001 — Contact still offered full-stack

It read *"Open to backend, full-stack, and software engineering roles."* That contradicted **SUP-002**: v1.1 removed Full-Stack Developer as a target role, and this line was the last place still offering it.

Now: *"Open to backend and software engineering opportunities. The fastest way to reach me is email."*

## Two tests failed, as designed

Both asserted the old label. They were **updated, not deleted** — and they failed exactly when the copy changed, which is the reviewed-diff mechanism working rather than a maintenance chore.

One reference to "View Projects" survives in `ui-primitives.test.tsx`. That is a fixture label exercising the `ButtonLink` component itself, not the hero, so it is correctly untouched.

## Tests and commands run

```
npm run check      exit 0 — 424 passed (30 files)
npm run test:e2e   exit 0 — 160 passed, 2 skipped
```

Both observed.

## Confidentiality review

Pass. Copy changes only, both already-public claims. Files staged by explicit path; `V2_HANDOFF_PRD.md` confirmed unstaged.

## Deployment impact

Two visible strings on the homepage. No route, schema, selector, or content-model change. The hero's primary action now resolves to an in-page anchor rather than a route — `scroll-padding-top` already accounts for the sticky header.

## Rollback

Revert this squash commit through a pull request.

## Known limitations

- Sections still do not adopt `data-surface`; that is Phase 3.
- Phase 0's remaining residuals (V2-P0-003 Docker, V2-P0-004 AI tool modelling) are untouched — both are claims about your own evidence and neither is answered yet.
