### PR TITLE
test: gate responsive widths and 200% zoom instead of reviewing them

### DIFF
--- a/e2e/responsive-hardening.spec.ts
+++ b/e2e/responsive-hardening.spec.ts
@@ -1,0 +1,99 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Responsive and zoom hardening (PRD 64, PRD 65).
+ *
+ * PRD 64 lists six review widths and PRD 65 lists 200% zoom, both as *manual*
+ * QA. Manual QA happens once, at the end, by whoever remembers — which is the
+ * shape of check this project has repeatedly found to be indistinguishable from
+ * no check at all. These are the automatable parts of that list, so they run on
+ * every pull request instead.
+ *
+ * The existing suite already covers 320px on two routes. This widens that to
+ * every listed width across every route, including the two the redesign changed
+ * most.
+ *
+ * What is deliberately NOT automated here: whether the layouts *look* right at
+ * each width. That is a judgement, it stays manual, and pretending otherwise
+ * would be the more dangerous kind of green.
+ */
+
+/** PRD 64's six widths, plus 320 — the narrowest the project supports. */
+const WIDTHS = [320, 375, 390, 768, 1024, 1280, 1440] as const;
+
+const ROUTES = [
+  { name: "Home", path: "/" },
+  { name: "Projects Index", path: "/projects" },
+  { name: "Project Detail", path: "/projects/jury-process-management-integration" },
+  { name: "Not Found", path: "/this-route-does-not-exist" },
+] as const;
+
+for (const route of ROUTES) {
+  test(`${route.name} has no horizontal overflow at any supported width`, async ({ page }) => {
+    const offenders: string[] = [];
+
+    for (const width of WIDTHS) {
+      await page.setViewportSize({ width, height: 900 });
+      await page.goto(route.path);
+      await page.waitForLoadState("networkidle");
+
+      const overflow = await page.evaluate(() => {
+        const root = document.documentElement;
+        const by = root.scrollWidth - root.clientWidth;
+
+        if (by <= 1) return null;
+
+        // Name the widest offenders. A bare "it overflows by 40px" sends the
+        // next person hunting through every element on the page.
+        const culprits = [...document.querySelectorAll("body *")]
+          .filter((element) => element.getBoundingClientRect().right > root.clientWidth + 1)
+          .slice(0, 3)
+          .map((element) => {
+            const classes = String(element.className).split(" ")[0] ?? "";
+            return `${element.tagName.toLowerCase()}${classes ? `.${classes}` : ""}`;
+          });
+
+        return { by, culprits };
+      });
+
+      if (overflow) {
+        offenders.push(
+          `${width}px overflows by ${overflow.by}px — ${overflow.culprits.join(", ")}`,
+        );
+      }
+    }
+
+    expect(offenders, `\n${offenders.join("\n")}\n`).toEqual([]);
+  });
+}
+
+/**
+ * 200% zoom (WCAG 1.4.4).
+ *
+ * The reason the type scale forbids a pure-vw clamp: a preferred value with no
+ * rem term does not respond to zoom, so text stays put while its container
+ * grows. tests/design/typography.test.ts enforces the rule on the tokens; this
+ * checks the result in a browser, where the two could still disagree.
+ */
+for (const route of ROUTES.slice(0, 3)) {
+  test(`${route.name} survives 200% browser zoom`, async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 });
+    await page.goto(route.path);
+    await page.waitForLoadState("networkidle");
+
+    await page.evaluate(() => {
+      document.body.style.zoom = "200%";
+    });
+    await page.waitForTimeout(200);
+
+    const overflow = await page.evaluate(() => {
+      const root = document.documentElement;
+      return root.scrollWidth - root.clientWidth;
+    });
+
+    expect(
+      overflow,
+      `content overflows horizontally by ${overflow}px at 200% zoom`,
+    ).toBeLessThanOrEqual(1);
+  });
+}


### PR DESCRIPTION
## Purpose

Phase 9 hardening. **The audit found no defects.** What it produced worth keeping is the audit itself, turned into tests that run on every pull request.

## What was measured, all clean

| Check | Coverage | Result |
|---|---|---|
| Horizontal overflow | 4 routes × 7 widths | none |
| 200% browser zoom | 3 routes | none |
| axe (critical/serious + always-blocking) | 4 routes × 7 widths = **28 scans** | none |
| LCP | warm, repeated ×3 per route | 216–316ms |
| CLS | every run | **0.0000** |
| Transfer | homepage / detail | 78KB / 63KB, fonts 62.7KB |

CLS is **below** the v1 baseline of 0.005 despite the page now carrying full-bleed dark bands and a second font family.

## Manual QA becomes a gate

§64 lists six review widths and §65 lists 200% zoom — both as *manual* QA. Manual QA happens once, at the end, by whoever remembers, which is the shape of check this project has repeatedly found indistinguishable from no check at all.

The automatable parts now run in CI: **seven widths across four routes**, plus zoom on the three content routes. The suite previously covered 320px on two routes.

**Verified by forcing a 1600px minimum on the `Section` primitive:**

```
320px overflows by 1280px — div.mx-auto, div.flex, div.flex
375px overflows by 1225px — div.mx-auto, div.flex, div.flex
…
1440px overflows by 160px — div.mx-auto, div.flex, div.w-full
```

Every width fails, each naming the offending elements — so a future failure is actionable rather than a bare number.

**What is deliberately not automated:** whether the layouts *look* right at each width. That's a judgement, it stays manual, and automating a proxy for it would be the more dangerous kind of green.

## ⚠️ A correction — I reported a defect that does not exist

While auditing focus visibility I reported that several buttons drew their focus ring in `currentColor` rather than the focus token — one at `#131a22` on `#0b0f14`, which would have been an invisible focus indicator. I then explained it as a transition on `outline-color`.

**Both were wrong.**

- `transition-duration` on those elements is **`0s`** — there is no transition
- Re-measuring with style settled shows **every ring using its surface's focus token**

The readings were an artifact of sampling computed style immediately after a synthetic `Tab`, before style recalculation. There is no focus-ring defect, and the fix I was about to write would have addressed nothing.

Recording it because a plausible-but-wrong finding that gets "fixed" is worse than one that gets retracted.

## Tests and commands run

```
npm run check      exit 0 — 436 passed (32 files)
npm run test:e2e   exit 0 — 211 passed, 2 skipped
```

Both observed. E2E 190 → 211 (+21 = 7 new tests × 3 engines).

## Confidentiality review

Pass. Test-only change, no content, no `src/` modification. `V2_HANDOFF_PRD.md` confirmed unstaged.

## Deployment impact

**None.** No production code changed.

## Rollback

Revert this squash commit through a pull request.

## Known limitations

- **This hardening ran against a page with a known gap.** Skills and AI Workflow are still unmigrated, so the widths and zoom were verified on sections that Phase 7 will rebuild. Those two sections need re-checking after Phase 7 — the gates now do that automatically, which is part of why they are worth having before Phase 7 rather than after.
- Lighthouse was not run; LCP and CLS were measured directly via PerformanceObserver, warm and repeated. A full Lighthouse pass belongs in Phase 10 against production.
