### PR TITLE
chore: close the v2 release and correct four stale documents

### DIFF
--- a/docs/product/PORTFOLIO_Decision_Ledger_v1.0.md
+++ b/docs/product/PORTFOLIO_Decision_Ledger_v1.0.md
@@ -5,9 +5,9 @@
 - **Product Name:** Randi Fajar Wicaksono Developer Portfolio
 - **Document Type:** Decision Ledger
 - **Version:** 1.0
-- **Status:** Updated After Product Model Approval
+- **Status:** Updated at the v2 release
 - **Owner:** Randi Fajar Wicaksono
-- **Last Updated:** 2026-08-04
+- **Last Updated:** 2026-08-16
 
 ---
 
@@ -76,21 +76,42 @@
 | DEC-047 | Not Found privacy | Unknown and non-public project routes have the same public result. | Confirmed | Round 5 approval |
 | DEC-048 | Version 1 boundary | Future features are not implicit Version 1 requirements. | Confirmed | Round 6 approval |
 
+### Version 2 design decisions
+
+Added at the v2 release, 2026-08-16. Each was approved by Randi merging the pull
+request that implemented it, after review — that is the approval basis, and it is
+recorded here rather than left implicit in Git history. Before this block the ledger
+described a product whose entire visual system was undocumented: fifty-seven rows,
+none of them mentioning a surface, a typeface, or a contrast floor.
+
+| ID | Topic | Decision | Status | Source |
+|---|---|---|---|---|
+| DEC-049 | Composition system | **Three surfaces — `light`, `neutral`, `dark` — alternating down the page.** Implemented as `[data-surface]` CSS-variable overrides, so components resolve colour through `var()` against whichever band contains them and no component knows which surface it is on. Still a single theme with no switcher. | Confirmed | v2 Phase 2a–7, PRs #50–#59 |
+| DEC-050 | Typefaces | **Archivo for display, Geist Sans for body.** Geist was already the body face; v2 added the display face only, chosen from a rendered specimen rather than from prose description. Both self-hosted by `next/font` at build time, so there is no external font request at runtime. | Confirmed | v2 Phase 2b |
+| DEC-051 | Type scale | **Nine tokenised steps using `clamp()`**, each preferred value carrying a `rem` term so browser text scaling still applies. Raw Tailwind size utilities are forbidden in `src/` and the ban is asserted. | Confirmed | v2 Phase 2b |
+| DEC-052 | Contrast floor | **4.8:1 text and 3.3:1 non-text — stricter than WCAG AA on purpose.** Both v1 contrast failures were within 4% of passing, so a floor set exactly at 4.5 would have admitted them again. Enforced by a 93-pair matrix parsing the shipping `globals.css`, in `quality` rather than only in axe. | Confirmed | v2 Phase 2a |
+| DEC-053 | Motion | **Motion is tokenised and reduced-motion is honoured structurally.** `prefers-reduced-motion` collapses the duration tokens and sets `animation-timeline: none`, because a scroll-driven timeline is progress-driven and a duration override alone does not stop it. | Confirmed | v2 Phase 2c |
+| DEC-054 | Project detail structure | **Two layers.** Layer A carries role, status, stack, problem and outcome above the deep content; Layer B is the existing sequence. Technology Stack moved from the deep sequence into Layer A. Asserted by measuring real vertical positions in a browser, not by DOM order. | Confirmed | v2 Phase 6 |
+| DEC-055 | Work Experience grouping | **Grouped by employer**, so an internship → contract → full-time progression at one employer reads as one relationship rather than three unrelated jobs. | Confirmed | v2 Phase 4 |
+
 ---
 
 ## Remaining Content Decisions
 
-These do not block technical design when represented by Draft placeholder content:
+Reconciled at the v2 release. Four of the seven were resolved during v1 content
+approval and stayed marked "Open Decision" here for eight months, which made this
+table useless as a to-do list — the two entries that genuinely still need Randi are
+the two easiest to overlook in a column of seven identical values.
 
 | ID | Topic | Status |
 |---|---|---|
-| OPEN-001 | Final professional headline | Open Decision |
-| OPEN-002 | Final professional summary | Open Decision |
-| OPEN-003 | Final third project | Open Decision |
-| OPEN-004 | Final skill classification | Open Decision |
-| OPEN-005 | Final professional photograph | Open Decision |
-| OPEN-006 | Safe project visuals | Open Decision |
-| OPEN-007 | Custom domain at launch | Open Decision |
+| OPEN-001 | Final professional headline | **Resolved** 2026-08-08 — supplied by Randi (`src/content/profile.ts`) |
+| OPEN-002 | Final professional summary | **Resolved** 2026-08-08 — supplied by Randi (`src/content/profile.ts`) |
+| OPEN-003 | Final third project | Open Decision — two published case studies; never a launch blocker (DEC-031) |
+| OPEN-004 | Final skill classification | **Resolved** 2026-08-08 — every classification confirmed as assigned (`src/content/skills.ts`) |
+| OPEN-005 | Final professional photograph | **Resolved** 2026-08-08 — supplied, converted to WebP at 400×400, live |
+| OPEN-006 | Safe project visuals | Open Decision — no diagram sanitised yet, which is also why Q9's schema field was not added |
+| OPEN-007 | Custom domain at launch | Open Decision — still the Vercel subdomain |
 
 ---
 

--- a/docs/product/PORTFOLIO_UX_UI_SPEC_v2.0.md
+++ b/docs/product/PORTFOLIO_UX_UI_SPEC_v2.0.md
@@ -1,15 +1,38 @@
 # Developer Portfolio — UX/UI Specification v2.0
 
-**Status:** Proposed. Awaiting the PRD §78 design review gate.
+**Status:** Implemented and live as of 2026-08-16.
 **Supersedes:** `PORTFOLIO_UX_UI_SPEC_v0.1.md` for everything in scope below.
 **Companion:** `PORTFOLIO_V2_ANALYSIS.md` carries the reasoning and the measurements;
 this document carries the rules.
 
-Nothing here is implemented. Approving this document is what unblocks Phase 2.
+Every rule below ships. Phases 2 through 9 were implemented as ten pull requests,
+each reviewed and merged by Randi, and each gated by `quality` and `e2e`. Where the
+implementation departed from a rule, the rule was amended here rather than left
+describing something that is not on the site — the departures are listed in §16.
 
-> **Citation note.** 38 in-code comments cite `UX n.n` against v0.1. This document
-> uses the prefix **`UX2 n.n`** so the two are never confused. A mapping table is in
-> §14. Implementation PRs update citations in the files they touch.
+> **Status accuracy matters more here than elsewhere.** Until this release the
+> header read *"Proposed. Awaiting the PRD §78 design review gate"* and *"Nothing
+> here is implemented"* — while the whole specification was live in production. That
+> is the same defect as v1.1 Issue 1, where the public `README.md` announced a site
+> that was "not yet deployed" months after launch. A specification that misreports
+> its own status is worse than a stale README, because the next release reads it as
+> a description of what still needs building.
+
+> **Citation note.** In-code comments cite `UX n.n` against v0.1; this document uses
+> the prefix **`UX2 n.n`** so the two are never confused. The mapping table in §14
+> resolves every cited v0.1 section.
+>
+> This note previously said *"implementation PRs update citations in the files they
+> touch."* Across seventeen touched files, not one v0.1 citation was replaced — seven
+> added a `UX2` citation beside the old one, and that is the correct behaviour. Many
+> v0.1 citations are deliberately historical: `globals.css` cites `UX 4.4` precisely
+> to record that v0.1 recommended `#64748B`, that the colour measured 4.34:1, and
+> that it was rejected. Rewriting it to `UX2 2` would erase the reason the token is
+> what it is.
+>
+> **Add the current rule; keep the historical citation.** The mapping table below,
+> not a find-and-replace, is what resolves a v0.1 reference. See the 2026-08-16 entry
+> in `release-audit.md`.
 
 ---
 
@@ -283,12 +306,28 @@ and status.
 
 Above the deep content: title, project type, delivery status, period, **My role**,
 core technologies, the problem in one or two sentences, and the outcome. No scrolling
-through fifteen sections to learn what the project was.
+the full case study to learn what the project was.
 
 ### UX2 8.3 — Project detail, Layer B
 
-The existing fifteen sections, unchanged in substance and order. Responsibility
+The existing deep sections, unchanged in substance and order. Responsibility
 separation survives the redesign (PRD §38, FAC-PROJECT-003).
+
+**Twelve deep sections, not fifteen.** Both clauses above said "fifteen sections"
+until this release, a number inherited from v0.1 UX 9.5 and repeated without being
+counted. UX 9.5 does list fifteen ordered items, but three of them are not deep
+content sections:
+
+| v0.1 UX 9.5 item | Where it actually is |
+|---|---|
+| 13. Technology Stack | **Layer A** — moved above the fold in Phase 6, so it left the sequence |
+| 14. Confidentiality Note | A conditional `sr-only` heading, present only when the project has a note |
+| 15. Related Navigation | A `<nav>` landmark after the article, not a section |
+
+Counted on the live site: **twelve** `<h2>` sections on the personal project and
+**thirteen** on the sanitised professional one, the difference being the conditional
+confidentiality note. This is Layer A's own justification, so overstating it by three
+overstated the problem the layer was built to solve.
 
 ---
 
@@ -409,26 +448,84 @@ LCP ≤ 2.5s, CLS < 0.1, INP < 200ms (PRD §46.1). Current CLS is 0.005 and the 
 | UX 7.3–7.9 sections | UX2 9 | Superseded |
 | UX 7.5 project cards | UX2 9.2 | Superseded — modules; SUP-006 order retained |
 | UX 7.8 AI visual weight | UX2 4.4 | **Mechanism replaced, decision retained** |
-| UX 9.5 detail sections | UX2 8.3 | Retained |
+| UX 9.5 detail sections | UX2 8.3 | Amended — Technology Stack moved to Layer A; see the count correction there |
 | UX 12 components | UX2 6 | Amended |
 | UX 18.3 social card | — | Retained |
 
+Completed at the v2 release, so that **every** section cited from code has a verdict.
+The table above previously covered fifteen sections while code cited seven more, and
+a mapping table with holes sends the reader to v0.1 without telling them whether what
+they find there still applies:
+
+| v0.1 | v2.0 | Status |
+|---|---|---|
+| UX 6.2 mobile navigation | UX2 5 | Retained — still the only `"use client"` component |
+| UX 7.10 footer | UX2 9 | Amended — dark surface, Phase 8 |
+| UX 8.2 header | UX2 5 | Amended — dark surface, Phase 3 |
+| UX 9.2 detail header area | UX2 8.2 | Superseded — replaced by Layer A |
+| UX 9.12 related navigation | — | Retained |
+| UX 15.2 headings | UX2 3 | Amended — tokenised scale, display face |
+| UX 17.2 missing photograph | — | Retained |
+
 ---
 
-## 15. Open Questions
+## 15. Open Questions — outcomes
 
-Blocking implementation:
+All resolved or deliberately deferred. Recorded rather than deleted, because a
+question that was answered and a question that was skipped look identical once the
+table is empty.
 
-| # | Question |
-|---|---|
-| Q1 | Display typeface — decide from `type-specimen.html` |
-| Q9 | Whether project diagrams need a schema field (PRD §51's six questions) |
+| # | Question | Outcome |
+|---|---|---|
+| Q1 | Display typeface | **Archivo**, chosen from the rendered specimen in Phase 2b. Self-hosted by `next/font`; body face is Geist Sans |
+| Q6 | Docker classified `currently-learning` while listed under the current role | **No change** — intentional. Confirmed 2026-08-16, SUP-008 |
+| Q7 | Whether Claude Code is the deliberate representative tool | **Yes** — no change. Confirmed 2026-08-16, SUP-009 |
+| Q8 | Contact copy and hero CTA wording | PRD wording adopted for both, at Randi's direction |
+| Q9 | Whether project diagrams need a schema field | **Deferred. Never answered, and v2 shipped without it** — see below |
+| Q10 | `remoteAvailability` rename | Still deferred. v1.1 assigned it to v2; v2 did not do it |
 
-Not blocking this specification, but open:
+**Q9 was listed as blocking implementation and implementation completed anyway.**
+That is worth stating plainly rather than quietly reclassifying it. The field would
+carry sanitised architecture diagrams, which is what would make module alternation
+visible on a case study and close PRD §34's missing problem/outcome summaries. It
+needs Randi's answer to PRD §51's six questions before any schema change, and no
+diagram has been sanitised for publication yet — so there was nothing to render even
+if the field existed. It is a v2.1 candidate, not an oversight closed by silence.
 
-| # | Question |
-|---|---|
-| Q6 | Docker classified `currently-learning` while listed under the current role |
-| Q7 | Whether Claude Code is the deliberate representative tool for AI practices |
-| Q8 | Contact copy and hero CTA wording — Randi's voice, and an availability claim |
-| Q10 | `remoteAvailability` rename, deferred to v2 by v1.1 |
+**Q10 is now twice-deferred.** v1.1 assigned the `remoteAvailability` rename to v2 on
+the grounds that renaming a schema field mid-release touches schema, selectors,
+components and tests for no reader-visible gain. v2 reached the same conclusion by
+never scheduling it. A field name that has now been deferred by two consecutive
+releases is either worth doing deliberately or worth closing as won't-fix.
+
+---
+
+## 16. Departures from the PRD, and why
+
+Every rule in this document ships. Three implementation decisions departed from what
+the PRD or the platform suggested, and each was taken with evidence rather than
+preference.
+
+**AI Workflow sits on `light`, where PRD §14 suggests "Dark / Neutral."** Dark is the
+*most* emphatic of the three surfaces. v1.1 measured this section at 1206px against
+Projects' 734 — 64% taller — on one of only two filled backgrounds, and deliberately
+demoted it so the page reads as a backend engineer who uses AI responsibly rather
+than an AI-tool operator who also does backend work. Following §14 literally would
+have re-promoted with colour exactly what v1.1 demoted with layout. Light is the
+least emphatic tier, so the section takes it. Now enforced by `SURFACE_RANK` in
+`tests/components/section-surface.test.tsx` (UX2 4.4, SUP-007).
+
+**Scroll-driven reveals cannot rely on `animation-timeline` alone.** Measured across
+all three engines in Phase 2c: Chromium and WebKit support it, **Firefox does not**.
+An earlier draft of this specification and its analysis both stated that WebKit did
+not either; that was wrong and was corrected after measuring rather than after
+assuming. The reduced-motion block neutralises time-driven animation, but a
+progress-driven timeline is not time-driven — so `animation-timeline: none` is set
+explicitly under `prefers-reduced-motion`, and the e2e probe skips where the property
+is unsupported instead of failing.
+
+**The non-text contrast floor is scoped, not blanket.** WCAG 1.4.11 covers what is
+needed to *identify UI components and their states*. It is applied to focus
+indicators and control-identifying borders, and deliberately not to decorative
+borders or badge tint fills. `NON_TEXT_SCOPE` in `src/domain/design/contrast.ts`
+records the scope so a later reader does not widen or narrow it by accident.

--- a/docs/release-audit.md
+++ b/docs/release-audit.md
@@ -586,3 +586,217 @@ and noindex state, and a sweep confirming **zero** stale positioning strings.
 | P33 Docker portability | Deferred by decision, unchanged |
 | `remoteAvailability` field name | Now holds "Open to opportunities", so the name is misleading. Renaming touches schema, selectors, components and tests for no reader-visible gain; left to v2 deliberately (SUP-004) |
 | Specification drift | The FAC, UX/UI spec, and both plans still describe the v1 positioning as historical record. Intentional, but a reader who opens them cold will need SUP-002 to interpret them |
+
+---
+
+## 2026-08-16 — v2 "Performance Engineering" release, closed
+
+| | |
+|---|---|
+| Commits audited | `9867be2` … `2ec9d00` on `production` — thirteen squash merges, PRs #47–#59 |
+| Deployment | `https://developer-portfolio-delta-three.vercel.app` |
+| Content state | All content Published. **No content was added, removed, or reworded in v2** |
+| Purpose | Close the v2 UI/UX evolution governed by `V2_HANDOFF.md` and `V2_HANDOFF_PRD.md`, and record what running the gate surfaced |
+
+v2 is a redesign that changed no claims. That is the most important line in this
+entry: every employer, date, title, metric and technology on the site is the one
+Randi approved in v1, and the two open content questions raised during v2 both came
+back "no change". A visual release is exactly where invented detail creeps in to fill
+a layout, and none did.
+
+### What shipped
+
+| Phase | Outcome | PR |
+|---|---|---|
+| — | v2 design analysis, 27 sections, with a measured visual baseline | #47 |
+| — | UX/UI specification v2.0, mockups, review gate | #48 |
+| 2a | Three surface tokens and a contrast gate — **zero visual change** | #49 |
+| 2b | Archivo display face and a nine-step tokenised type scale | #50 |
+| 2c | Motion tokens, reduced-motion, three accessibility gaps closed | #51 |
+| 2c | Hero points at Experience; "full-stack" dropped from Contact | #52 |
+| 3 | The `Section` primitive; hero and header on dark | #53 |
+| 4 | Work Experience grouped by employer | #54 |
+| 5 | Selected Work as editorial modules; index adapted | #55 |
+| 6 | Fast-scan layer on Project Detail | #56 |
+| 8 | Page closes on dark; social card palette derived from the tokens | #57 |
+| 9 | Responsive widths and 200% zoom gated instead of eyeballed | #58 |
+| 7 | Skills and AI Workflow surfaces; SUP-007 finally enforced | #59 |
+
+Suite: **408 tests in 28 files → 436 in 32.** End-to-end **149 → 211** across three
+engines, 2 documented skips. Seven new test files, every one added because something
+was being held in place by nothing.
+
+### The release gate failed twice, and only one was the repository's fault
+
+`npm run check` and `npm run test:e2e` were green on the merged tree. `npm run
+release:check` — those two plus `validate:release`, `check:links` and `audit:prod` —
+exited **1**.
+
+**First failure: mine.** `SITE_URL is not set`. Production has it set; the canonical
+link, `og:url` and every `sitemap.xml` entry are absolute and correct. I had run the
+command without the environment that `release-checklist.md` line 41 documents.
+Recorded because the failure text is identical to what a genuinely misconfigured
+production would produce, and the difference is only visible if you go and look at
+the deployed page instead of reading the error.
+
+**Second failure: real.** `nanoid@3.3.17`, high severity, reached through
+`next@16.3.0 → postcss@8.5.23 → nanoid`. Fixed by `npm update nanoid` to **3.3.18**:
+postcss declares `^3.3.16`, so the patched version was already inside the permitted
+range. Three lines of `package-lock.json`, no Next bump, no `overrides` entry, and
+none of the deliberate `dependabot.yml` ceilings touched. `audit:prod` then reported
+`found 0 vulnerabilities`.
+
+Worth stating plainly: **`quality` and `e2e` never run `audit:prod`.** All thirteen
+v2 pull requests passed CI with that advisory outstanding, because the dependency
+audit lives only in `release:check`, which only runs at a release. The vulnerability
+was not reachable in a way that mattered for a static portfolio, but the structural
+point stands — CI being green for thirteen consecutive merges said nothing at all
+about dependency security.
+
+### The performance measurement was wrong the first time
+
+First Lighthouse pass against production: Home **86**, Projects 91, Detail 88 — below
+the ≥ 90 of NFAC-PERF-002.
+
+It was taken while `release:check` was building the site and driving three browser
+engines on the same machine. The 2026-08-09 entry above records this exact trap in
+the opposite direction, where a cold-deployment reading produced a pessimistic risk
+assessment that a warm re-measurement disproved. Re-run on an idle machine, three
+runs per route:
+
+| Page | Runs | Median | LCP | CLS |
+|---|---|---:|---|---|
+| Home | 88, 90, 92 | **90** | 2.3–2.4 s | 0 |
+| Projects Index | 90, 92, 92 | **92** | 2.0–2.2 s | 0–0.006 |
+| Project Detail | 91, 92, 90 | **91** | 2.1–2.3 s | 0 |
+
+Accessibility, Best Practices and SEO: **100 on all three pages.**
+
+NFAC-PERF-001 (P0) passes with room: LCP ≤ 2.4 s against a 2.5 s limit, CLS
+effectively zero against 0.1. NFAC-PERF-002 (P1) passes **at the median with no
+headroom** — Home's median is exactly 90, and one of its three runs scored 88.
+
+The LCP element is the hero photograph, which the release checklist names as the
+first thing to suspect. It transfers at **16 KB**, so payload is not the cost.
+
+v2 added exactly one webfont — Archivo, the display face; Geist was already the body
+face in v1.1. The two together transfer **63 KB**, and the stylesheet blocks render
+for 150 ms. So the v2-shaped candidate is roughly half of that 63 KB plus whatever
+the surface system added to the stylesheet, not the whole of either.
+
+This is not a launch blocker — it is a P1 that passes — but "passes at exactly the
+threshold" is worth writing down, because the next change that adds a kilobyte to the
+critical path will be the one that breaks it, and it will look like that change's
+fault.
+
+### Four documents were describing a product that no longer existed
+
+Not found by a tool. Found by reading the documents the release was supposed to be
+closing, which is the only way this class of defect is ever found.
+
+| Document | Said | Was |
+|---|---|---|
+| `PORTFOLIO_UX_UI_SPEC_v2.0.md` | "Proposed. Awaiting the PRD §78 design review gate" and **"Nothing here is implemented"** | Every rule in it live in production |
+| `src/content/media.ts` | "Media Assets — DRAFT … every asset here is Draft, and the referenced files do not exist yet" | Both assets Published; the photograph is production's measured LCP element |
+| Decision Ledger, open decisions | Seven items, all "Open Decision" | Four resolved on 2026-08-08 and left unmarked for eight months |
+| Decision Ledger, confirmed decisions | Fifty-seven rows | **None** mentioning a surface, a typeface, a type scale, a contrast floor, or motion |
+
+This is v1.1 Issue 1 again — the public `README.md` announcing a site that was "not
+yet deployed" long after launch — and it recurred inside a release whose own handoff
+opened by cataloguing how stale `V2_HANDOFF.md` had become. The pattern is not
+carelessness about documents. It is that **a document's status line is the one part
+of it that nothing ever executes.** Prose describing behaviour eventually gets
+contradicted by the running site; a header saying "Proposed" is contradicted by
+nothing, forever.
+
+All four are corrected in this release, and the seven v2 design decisions are now
+DEC-049 through DEC-055 with their approval basis recorded — Randi's merge of the
+pull request that implemented each.
+
+### A stated process that was not followed, and should not have been
+
+The v2.0 specification instructed: *"Implementation PRs update citations in the files
+they touch."* Seventeen files carrying v0.1 `UX n.n` citations were modified during
+v2. **Not one v0.1 citation was replaced.** Seven of the seventeen gained a `UX2`
+citation alongside the old one; the other ten gained nothing.
+
+The instruction was not followed, and following it would have made the repository
+worse. `globals.css` cites `UX 4.4` precisely in order to record that v0.1
+recommended `#64748B`, that the colour measured **4.34:1**, and that it was rejected.
+Rewriting that citation to `UX2 2` would delete the reason the token is what it is,
+and leave a number with no provenance for someone to later "simplify".
+
+What actually emerged in practice — add the current rule, keep the historical one —
+is the correct behaviour, and it happened in seven files without ever being written
+down. Some citations point at a governing rule and some are deliberately historical,
+and no find-and-replace can tell them apart. So the instruction is now replaced by
+the mapping table as the sole resolution mechanism, and the table was completed: it
+covered fifteen sections while code cited seven more, meaning a reader following a
+citation into v0.1 had no way to learn whether what they found there still applied.
+
+The ten files that gained nothing are not a defect to fix in bulk. They are a reason
+the mapping table has to be complete, which it now is.
+
+### A number that was never counted
+
+Both halves of the Layer A rule said the case study made a reader scroll through
+"fifteen sections". Counted on the live site: **twelve** `h2` sections on the personal
+project, thirteen on the sanitised professional one, the difference being a
+conditional screen-reader-only confidentiality heading.
+
+The fifteen came from v0.1 UX 9.5, which does list fifteen ordered items — but three
+of them are not deep sections. Technology Stack moved into Layer A during Phase 6,
+Confidentiality Note is an `sr-only` heading, and Related Navigation is a `nav`
+landmark. The figure was inherited and repeated, never counted.
+
+It mattered here more than a wrong number usually does, because the sentence was
+Layer A's own justification. The feature is right; the case made for it overstated
+the problem by three sections.
+
+### What v2 gated that v1 did not
+
+| Now enforced | Previously |
+|---|---|
+| Contrast, 93 pairs against the shipping `globals.css`, in `quality` | axe only, which cannot see a `color-mix` against `transparent` — the cause of v1's second contrast failure |
+| AI section never more emphatic than Experience or Selected Work (SUP-007) | **Nothing.** Measured once in pixels during v1.1, then held by nothing at all |
+| Homepage surface sequence, and section omission | Nothing |
+| Project detail fast-scan order, by real vertical position in a browser | Nothing |
+| Reduced motion, including `animation-timeline` | Nothing; a blanket duration override cannot stop a progress-driven timeline |
+| Seven viewport widths and 200% zoom | Manual review |
+| Type scale tokenisation and `rem`-based `clamp()` | Nothing |
+
+Each was verified by breaking what it guards and watching it fail. SUP-007 is the one
+worth naming: promoting AI Workflow to `dark` fails with `expected 3 to be less than
+or equal to 1`, and to `neutral` with `expected 2 to be less than or equal to 1`.
+Since Phase 3 that assertion had been printing `SUP-007 rank rule not yet enforceable`
+because two of its three inputs had no surface yet — so its silence proved nothing
+until Phase 7 supplied the third.
+
+### Production verification
+
+| Check | Result |
+|---|---|
+| `/`, `/projects`, both case studies, `/resume.pdf`, `/sitemap.xml`, `/robots.txt`, `/opengraph-image` | all 200, correct content types |
+| `/projects/does-not-exist`, `/projects/draft`, `/admin` | all 404 |
+| Surface sequence, read from the deployed page | `dark → dark → light → dark → light → neutral → light → dark → dark`, **0 sections without a surface** |
+| Neutral token as served | `--color-background:#eaeff5`, identical to the local capture |
+| Identity and positioning | "Backend Developer" throughout; no "full-stack" on the homepage |
+| Contact targets | `randifajar2307@gmail.com`, `github.com/randifajar`, `linkedin.com/in/randifajar` — match DEC-014, 015, 016 |
+| Draft content reachable | None exists — all 26 content records are `published` |
+
+LinkedIn returns HTTP 999 to automated requests. That is its standard anti-bot
+response rather than a broken link, but it does mean no automated check can confirm
+it — the checklist's manual "open by hand" step is the only thing that can, and it
+remains Randi's to do.
+
+### Outstanding after v2
+
+| Item | State |
+|---|---|
+| Source rollback rehearsal | **Still not done.** v2 merged thirteen more pull requests and not one was a `git revert`, so thirteen further opportunities passed unused. Carried since v1 P32, now across three releases |
+| Q9 — project diagram schema field | Deferred. Listed as blocking implementation; implementation completed without it. Nothing to render until a diagram is sanitised (OPEN-006) |
+| Q10 — `remoteAvailability` rename | Deferred by v1.1 to v2, and by v2 to nothing. Twice-deferred is worth closing as a decision either way |
+| Home Lighthouse headroom | Median exactly 90 against a P1 floor of 90 |
+| `audit:prod` outside CI | The nanoid advisory survived thirteen green CI runs. Moving the audit into `quality`, or adding a scheduled run, would close it |
+| OPEN-003, OPEN-006, OPEN-007 | Third project, safe project visuals, custom domain — genuinely open |
+| `V2_HANDOFF_PRD.md` | Still untracked, pending Randi's decision on whether it is published |

--- a/package-lock.json
+++ b/package-lock.json
@@ -8234,9 +8234,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.17",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.17.tgz",
-      "integrity": "sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",

--- a/src/content/media.ts
+++ b/src/content/media.ts
@@ -1,15 +1,25 @@
 import { defineMediaAsset } from "@/domain/content/define";
 
 /**
- * Media Assets — DRAFT.
+ * Media Assets — PUBLISHED.
  *
- * The photograph is a Confirmed inclusion (DEC-019) but the actual image, crop,
- * and alt text are open (OPEN-005). Safe project visuals are open (OPEN-006).
+ * Both assets below are Published, both files resolve, and both are verified
+ * serving in production. OPEN-005 is resolved: the photograph was supplied on
+ * 2026-08-08 with its crop and alt text.
  *
- * Every asset here is Draft, and the referenced files do not exist yet. That is
- * deliberate: FAC-HOME-006 and FAC-PROJECT-006 require the site to degrade to
- * text when optional media is unavailable, so building against absent media is
- * the honest default rather than a gap.
+ * This header said "DRAFT" and "every asset here is Draft, and the referenced
+ * files do not exist yet" until 2026-08-16, by which point the photograph had
+ * been live for months and was the measured Largest Contentful Paint element of
+ * the homepage. Corrected at the v2 release, alongside the same class of stale
+ * status claim in the v2.0 specification header.
+ *
+ * The site still degrades to text when optional media is absent — FAC-HOME-006
+ * and FAC-PROJECT-006 require it, and that behaviour is tested rather than
+ * merely no longer exercised by this file.
+ *
+ * OPEN-006, safe project visuals, is genuinely still open. No diagram has been
+ * sanitised for publication, which is also why the diagram schema field (Q9)
+ * was never added: there is nothing yet to render.
  *
  * NFAC-SEC-002 and TD 16.4: no project screenshot or diagram may expose
  * internal identifiers, internal URLs, customer or student data, or private


### PR DESCRIPTION
Phase 10, the v2 release. Runs the full gate, records the sixth `release-audit.md` entry, and fixes what running the gate exposed.

**No content changed in v2 at all** — not one employer, date, title, metric or technology. Both open content questions came back "no change". A visual release is exactly where invented detail creeps in to fill a layout, and none did.

## The gate failed twice, and only one was ours

`npm run check` and `npm run test:e2e` were green. `npm run release:check` — those two plus `validate:release`, `check:links` and `audit:prod` — exited **1**.

**First failure: mine.** `SITE_URL is not set`. Production has it; the canonical link, `og:url` and every `sitemap.xml` entry are absolute and correct. I ran the command without the environment `release-checklist.md:41` documents. Recorded because that failure text is identical to what a genuinely misconfigured production would produce, and the difference is only visible if you go and look at the deployed page instead of reading the error.

**Second failure: real.** `nanoid@3.3.17`, high severity, via `next@16.3.0 → postcss@8.5.23 → nanoid`. Fixed to **3.3.18**, which postcss's own `^3.3.16` already permitted — three lockfile lines, no Next bump, no `overrides` entry, and none of the deliberate `dependabot.yml` ceilings touched.

> **Worth your attention: `audit:prod` runs only inside `release:check`, never in `quality` or `e2e`.** All thirteen v2 pull requests passed CI with that advisory outstanding. The vulnerability was not reachable in a way that mattered for a static portfolio, but CI being green thirteen consecutive times said nothing whatsoever about dependency security. Listed as outstanding.

## Lighthouse was measured wrong the first time

First pass: Home **86**, Projects 91, Detail 88 — below the ≥ 90 P1 floor. It was taken while `release:check` was building the site and driving three browser engines on the same machine. The 2026-08-09 audit entry records this exact artefact in the opposite direction.

Re-measured on an idle machine, three runs per route:

| Page | Runs | Median | LCP | CLS |
|---|---|---:|---|---|
| Home | 88, 90, 92 | **90** | 2.3–2.4 s | 0 |
| Projects Index | 90, 92, 92 | **92** | 2.0–2.2 s | 0–0.006 |
| Project Detail | 91, 92, 90 | **91** | 2.1–2.3 s | 0 |

Accessibility, Best Practices, SEO: **100 on all three pages.** NFAC-PERF-001 (P0) passes with room. NFAC-PERF-002 (P1) passes **at the median with no headroom** — Home's median is exactly 90 and one run scored 88. Recorded as a pass, not reported as a clean one.

LCP element is the hero photograph, which the checklist names as the first suspect — but it transfers at **16 KB**, so payload is not the cost. v2 added exactly one webfont (Archivo; Geist was already the body face).

## Four documents were describing a product that no longer existed

Found by reading the documents the release was meant to be closing. No tool finds this.

| Document | Said | Was |
|---|---|---|
| `PORTFOLIO_UX_UI_SPEC_v2.0.md` | "Proposed. Awaiting the §78 design review gate" / **"Nothing here is implemented"** | Every rule live in production |
| `src/content/media.ts` | "Media Assets — DRAFT … the referenced files do not exist yet" | Both Published; the photograph is production's measured LCP element |
| Ledger — open decisions | Seven items, all "Open Decision" | Four resolved 2026-08-08, unmarked for eight months |
| Ledger — confirmed decisions | Fifty-seven rows | **None** naming a surface, typeface, type scale, contrast floor, or motion |

This is v1.1 Issue 1 again — the README announcing a site that was "not yet deployed" long after launch — recurring inside a release whose own handoff opened by cataloguing how stale `V2_HANDOFF.md` had become. The pattern isn't carelessness. **A document's status line is the one part of it that nothing ever executes.**

v2's seven design decisions are now **DEC-049 … DEC-055**, with the approval basis recorded as your merge of the PR that implemented each.

## Three things I got wrong, corrected by counting

- **"Fifteen sections."** Layer A's own justification said a reader scrolls through fifteen. Counted live: **twelve** `h2` sections, thirteen where the conditional `sr-only` confidentiality heading applies. The surplus three came from v0.1 UX 9.5 — Technology Stack (which Phase 6 moved *into* Layer A), the `sr-only` note, and a `nav` landmark. The feature is right; the case made for it overstated the problem by three.
- **Citations.** I first wrote "sixteen files, none updated". It is **seventeen**, and seven of them added a `UX2` citation beside the old one. That emergent practice — add the current rule, keep the historical citation — is correct, and following the spec's actual instruction would have made things worse: `globals.css` cites `UX 4.4` in order to record that v0.1 recommended `#64748B`, that it measured **4.34:1**, and that it was rejected. The instruction is replaced by the mapping table, which was completed (it covered fifteen sections while code cited seven more).
- **Webfonts.** I attributed both to v2; only Archivo is new.

## Verification, all observed

```
SITE_URL=… npm run release:check      exit 0
  check              436 passed, 32 files
  validate:release   passed
  check:links        every target ok, no BROKEN
  test:e2e           211 passed, 2 skipped, three engines
  audit:prod         found 0 vulnerabilities
```

**Production smoke:** every route 200 with correct content types; `/projects/does-not-exist`, `/projects/draft`, `/admin` all 404; surface sequence `dark → dark → light → dark → light → neutral → light → dark → dark` with 0 sections lacking one; contact targets match DEC-014/015/016; all 26 content records `published`, so no draft content exists to leak.

**Keyboard pass, against production:** 52 tab stops across three routes, **0** without a visible focus ring.

**Deployment impact:** none. Docs, one source comment, and a lockfile line. No visible UI change, so no screenshots.

**Still yours to do:** LinkedIn returns HTTP 999 to automated requests — its standard anti-bot response, not a broken link, but it means no automated check can confirm it. The checklist's "open by hand" step is the only thing that can.

## Outstanding after v2

| Item | State |
|---|---|
| Source rollback rehearsal | **Still not done.** v2 merged thirteen more PRs and not one was a `git revert`. Carried since v1 P32, now across three releases |
| `audit:prod` outside CI | The nanoid advisory survived thirteen green CI runs |
| Q9 — diagram schema field | Listed as blocking; implementation completed without it. Nothing to render until a diagram is sanitised (OPEN-006) |
| Q10 — `remoteAvailability` rename | Deferred by v1.1 to v2, and by v2 to nothing. Twice-deferred is worth closing either way |
| Home Lighthouse headroom | Median exactly 90 against a P1 floor of 90 |
| OPEN-003, OPEN-006, OPEN-007 | Third project, safe project visuals, custom domain |
| `V2_HANDOFF_PRD.md` | Still untracked, pending your decision on publishing it |
