### PR TITLE
fix: stop the experience-grouping test timing out under load

### DIFF
--- a/docs/release-audit.md
+++ b/docs/release-audit.md
@@ -987,9 +987,35 @@ runner being fast enough is the same shape as a contrast ratio that passes by 4%
 The structural point is the one that matters, and it demonstrated itself: **a
 nondeterministic failure in a required check converts a seven-minute rollback into an
 unbounded one.** This finding was written after the first occurrence, and the second
-occurrence then blocked the verification of the rehearsal's own restore commit. Left
-as a finding here rather than fixed in the same change, because a test-infrastructure
-fix is a different objective from a rehearsal record and deserves its own review.
+occurrence then blocked the verification of the rehearsal's own restore commit.
+
+**Fixed the same day, in its own change.** The cause was reproduced deterministically
+before anything was altered: a test that times out with an async render in flight
+mounts DOM after cleanup has run, so the next test finds it. Forcing that condition
+produced both failures verbatim — `Test timed out`, then `Found multiple elements with
+the text: 2024 — Present`.
+
+Two mitigations were tried and one was discarded:
+
+- **`beforeEach(cleanup)` — rejected.** It looks like the obvious fix and the probe
+  disproved it. The next test begins almost immediately after an abort, so the
+  pre-test cleanup runs *before* the delayed orphan lands. Shipping it would have
+  added a hook that reads as protection and is not.
+- **Remove the per-test dynamic import — kept.** `experience-grouping.test.tsx` now
+  imports the component once and swaps a `vi.hoisted` fixture underneath it. The
+  first test drops from **1118ms to 342ms**, and the module load moves out of the
+  test body entirely, where no single test's timeout applies.
+
+`testTimeout` is also now set explicitly to 20000ms rather than inherited from
+vitest's 5000ms default, because the files that load a module by a runtime-computed
+name cannot be restructured the same way — `homepage-section-omission.test.tsx` does
+six dynamic imports, worst case 573ms.
+
+Verified by breaking what it guards: global-instead-of-consecutive grouping fails the
+returning-employer test, never grouping fails two more, and marking every role current
+fails the fourth — so the restructured plumbing still bites. Ten consecutive
+full-suite runs passed 436/436, which is corroboration rather than proof at a base
+rate of roughly two in twelve; the mechanical argument is the stronger one.
 
 **2. A revert is all-or-nothing.** #59 bundled a presentational change with two
 decision records, so rolling back the visuals also rolled back the Docker and Claude

--- a/tests/components/experience-grouping.test.tsx
+++ b/tests/components/experience-grouping.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen, within } from "@testing-library/react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+
+import { ExperienceSection } from "@/components/sections/experience-section";
 
 /**
  * Employer grouping.
@@ -23,9 +25,31 @@ import { afterEach, describe, expect, it, vi } from "vitest";
  * produce it means shipping the bug first.
  */
 
-afterEach(() => {
-  vi.resetModules();
-});
+/**
+ * The component is imported once, and each test swaps the fixture underneath it.
+ *
+ * It used to call `vi.resetModules()` and re-`import()` the component inside
+ * every test, which meant re-transforming and re-evaluating the whole component
+ * subgraph four times. That put ~1100ms of module work inside the *first* test
+ * body against vitest's 5000ms default — a margin of about 4.5x, where the
+ * other three tests had 150x.
+ *
+ * Under full-suite parallelism that margin ran out twice on 2026-08-17, and the
+ * failure was worse than a slow test: vitest aborts at the await point, but the
+ * import keeps resolving and calls `render()` afterwards, so a DOM belonging to
+ * no test appeared during the *next* one. It failed with "Found multiple
+ * elements", pointing the reader at an assertion that was never wrong.
+ *
+ * `vi.hoisted` gives the mock factory a mutable fixture it can close over, so
+ * the module graph loads once at import time and no test body starts async work
+ * that can outlive it. See the 2026-08-17 entry in docs/release-audit.md.
+ */
+const fixture = vi.hoisted(() => ({ roles: [] as unknown[] }));
+
+vi.mock("@/domain/content/selectors", () => ({
+  getPublishedExperience: () => fixture.roles,
+  getTechnologyNames: () => [],
+}));
 
 interface RoleOverrides {
   readonly id: string;
@@ -46,21 +70,14 @@ function role(overrides: RoleOverrides) {
   };
 }
 
-async function renderWith(roles: readonly ReturnType<typeof role>[]) {
-  vi.resetModules();
-
-  vi.doMock("@/domain/content/selectors", () => ({
-    getPublishedExperience: vi.fn(() => roles),
-    getTechnologyNames: vi.fn(() => []),
-  }));
-
-  const { ExperienceSection } = await import("@/components/sections/experience-section");
+function renderWith(roles: readonly ReturnType<typeof role>[]) {
+  fixture.roles = [...roles];
   return render(<ExperienceSection />).container;
 }
 
 describe("roles group under one employer heading", () => {
-  it("names the employer once, not once per role", async () => {
-    await renderWith([
+  it("names the employer once, not once per role", () => {
+    renderWith([
       role({
         id: "a",
         companyName: "Acme",
@@ -89,8 +106,8 @@ describe("roles group under one employer heading", () => {
     expect(screen.getAllByRole("heading", { level: 4 })).toHaveLength(3);
   });
 
-  it("spans the employer from earliest start to Present while a role is current", async () => {
-    await renderWith([
+  it("spans the employer from earliest start to Present while a role is current", () => {
+    renderWith([
       role({
         id: "a",
         companyName: "Acme",
@@ -117,8 +134,8 @@ describe("roles group under one employer heading", () => {
    * unbroken run at Acme that never happened, and moving Other out of
    * chronological position. Grouping consecutive runs keeps the history true.
    */
-  it("does not merge a returning employer across an intervening one", async () => {
-    const container = await renderWith([
+  it("does not merge a returning employer across an intervening one", () => {
+    const container = renderWith([
       role({
         id: "a",
         companyName: "Acme",
@@ -158,8 +175,8 @@ describe("roles group under one employer heading", () => {
     expect(within(groups[2] as HTMLElement).getByText("Junior Engineer")).toBeInTheDocument();
   });
 
-  it("marks the current role and no other", async () => {
-    await renderWith([
+  it("marks the current role and no other", () => {
+    renderWith([
       role({
         id: "a",
         companyName: "Acme",

--- a/vitest.config.mts
+++ b/vitest.config.mts
@@ -14,6 +14,24 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
     include: ["tests/**/*.test.{ts,tsx}"],
+    // Chosen rather than inherited. Vitest's default is 5000ms, which was never
+    // a decision anyone made about *this* workload.
+    //
+    // Some tests must load a module by a name computed at runtime, so they call
+    // vi.resetModules() and await import() inside the test body. That puts a
+    // full re-transform and re-evaluation of a component subgraph on the clock.
+    // homepage-section-omission.test.tsx does it six times, worst case 573ms.
+    //
+    // experience-grouping.test.tsx used to do the same at ~1100ms — a margin of
+    // about 4.5x — and on 2026-08-17 that margin ran out twice under full-suite
+    // parallelism. It has since been restructured to import once, but the files
+    // that genuinely need a computed module name cannot be, so they get real
+    // headroom instead.
+    //
+    // A timeout is not a substitute for a test being fast; it is protection
+    // against a machine being slow. The 2026-08-17 entry in
+    // docs/release-audit.md records what the failure actually looked like.
+    testTimeout: 20_000,
     coverage: {
       provider: "v8",
       reporter: ["text", "lcov"],


### PR DESCRIPTION
Fixes the flake found during the source-rollback rehearsal — the one that failed twice and the second time blocked verification of the rehearsal's own restore commit.

## Reproduced before anything was changed

An intermittent failure I can't make fail on demand is a fix I can't verify. So the cause was forced first:

> A test that times out **with an async render still in flight** mounts DOM after `afterEach(cleanup)` has already run. That DOM belongs to no test, and the next one inherits it.

Forcing exactly that produced both failures verbatim:

```
Error: Test timed out in 150ms.
TestingLibraryElementError: Found multiple elements with the text: 2024 — Present
```

One cause, two failures — and the second sent the reader to an assertion that was never wrong.

## One mitigation was tried and rejected

**`beforeEach(cleanup)` is the obvious fix, and the probe disproved it.** I wrote it, ran the probe, and it still cascaded. The next test begins almost immediately after an abort, so the pre-test cleanup runs *before* the delayed orphan lands.

It is not in this PR. Shipping it would have added a hook that reads as protection and is not — which is the exact failure mode this repository keeps finding in its own gates.

## What is here is the root cause

`renderWith` called `vi.resetModules()` and re-`import()`ed the component **inside every test**, re-transforming the whole component subgraph four times. That put ~1100ms of module work inside the *first* test body against vitest's 5000ms default:

| | Margin against 5000ms |
|---|---|
| Test 1 (paid the module cost) | **4.5×** |
| Tests 2–4 | ~150× |

It now imports the component once and swaps a `vi.hoisted` fixture underneath it.

| | Before | After |
|---|---|---|
| Test 1, in-body | 1118ms | **342ms** |
| Module load | inside the test body | file-level import, where no single test's timeout applies |

`testTimeout` is also now **set explicitly to 20000ms** rather than inherited. 5000ms was never a decision anyone made about this workload, and the files that load a module by a runtime-computed name genuinely cannot be restructured this way — `homepage-section-omission.test.tsx` does six dynamic imports, worst case 573ms, an 8.7× margin against the 4.5× that actually failed.

Verified live rather than assumed: a 6-second test passes under the config and fails with `--testTimeout=5000`.

## The tests still bite

I rewrote the mocking plumbing, so the tests could have started passing vacuously. Broken deliberately to confirm they don't:

| Break | Result |
|---|---|
| Group globally by name instead of consecutively | returning-employer test fails |
| Never group at all (the pre-v2 bug) | two tests fail |
| Mark every role current | the fourth fails |

Source restored clean afterwards — `git diff src/` empty.

## Verification

```
npm run check      exit 0, 436 passed, 32 files
npm run test:e2e   exit 0, 211 passed, 2 skipped, three engines
```

Plus **ten consecutive full-suite runs, all 436/436**. That is corroboration, not proof, at a base rate of roughly two in twelve — the mechanical argument is the stronger one, and it is stated that way in the audit entry too.

## Scope

Three files: the test, the vitest config, and the `release-audit.md` finding, which said the fix was deliberately deferred and now records what was done. No source change — `src/` is untouched.

**Confidentiality:** no new content. PRD absent from the commit (`0`).

**Deployment impact:** none. Test infrastructure only.

**Rollback notes:** a single `git revert`, now a rehearsed procedure with a measured cost of about seven minutes.
