### PR TITLE
ci: run the production dependency audit on every change

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,3 +92,39 @@ jobs:
           name: playwright-report
           path: playwright-report/
           retention-days: 7
+
+  # Added 2026-08-18. `audit:prod` previously ran only inside `release:check`
+  # and `release-audit.yml`, both of which are manual — so a high-severity
+  # advisory in `nanoid` reached `production` through thirteen consecutive
+  # green CI runs and was found only when the v2 release gate was run by hand.
+  #
+  # Deliberately its own job rather than a step inside `quality`. `quality` and
+  # `e2e` are the two required status checks, and a dependency audit fails for
+  # a reason that has nothing to do with the pull request in front of it: an
+  # advisory published upstream overnight would block every merge, including
+  # the revert you would need during an incident. The 2026-08-17 rehearsal
+  # recorded exactly that hazard.
+  #
+  # So this reports, loudly and on every change, without holding the merge
+  # button hostage. Promote it to a required check only as a deliberate
+  # decision, knowing what it costs.
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Production dependencies only. Dev-tool advisories do not ship to a
+      # visitor, and failing on them would train everyone to ignore this job.
+      - name: Production dependency audit
+        run: npm run audit:prod

--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -1,0 +1,52 @@
+name: Security Audit
+
+# The per-pull-request `audit` job in ci.yml only runs when something changes.
+# A dependency advisory is published by someone else, on their schedule, against
+# a lock file that has not moved — which is exactly what happened with `nanoid`:
+# no pull request introduced it, and it sat in `production` until the v2 release
+# gate was run by hand on 2026-08-16.
+#
+# With v2 closed, this repository can now go weeks without a pull request while
+# remaining a live, publicly linked job-search asset. A scheduled sweep is the
+# only thing that notices an advisory during a quiet period.
+#
+# Kept out of ci.yml deliberately. `quality` and `e2e` are the two required
+# status checks and their names are contractual with the branch ruleset
+# (github-configuration.md section 4); adding schedule-only conditionals to that
+# file risks the contract for no gain.
+on:
+  schedule:
+    # Daily at 21:00 UTC, which is 04:00 Asia/Jakarta. Daily rather than weekly
+    # because an advisory is published on its author's schedule, not ours, and a
+    # week of exposure on a live job-search asset is a week too long. On Mondays
+    # it lands an hour after Dependabot 03:00, so a fix and the advisory that
+    # motivates it tend to surface together.
+    - cron: "0 21 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  audit:
+    name: audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version-file: .nvmrc
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Production dependencies only, matching ci.yml and release:check. A
+      # failure here means an advisory landed with no change on our side, so the
+      # next step is `npm audit fix` scoped to the offending package — or a
+      # documented decision, per release-checklist.md section 8.
+      - name: Production dependency audit
+        run: npm run audit:prod

--- a/docs/governance/github-configuration.md
+++ b/docs/governance/github-configuration.md
@@ -165,10 +165,27 @@ e2e
 Use the exact workflow job names. These match the two jobs defined in the
 Technical Design CI workflow.
 
-Dependency and secret protection are covered without a separate required check:
-the production dependency audit runs inside `npm run release:check`, and
+Dependency and secret protection are covered without a separate required check.
 Dependabot alerts, secret scanning, and push protection are configured in
-section 6.
+section 6, and the production dependency audit runs in three places:
+
+| Where | When | Blocking |
+|---|---|---|
+| `ci.yml` job `audit` | every pull request and push | no |
+| `security-audit.yml` | daily, 21:00 UTC | no |
+| `npm run release:check` | manually, at a release | yes, locally |
+
+**The `audit` job is deliberately not a required status check.** Adding it would
+mean an advisory published upstream overnight blocks every merge — including the
+revert needed to recover from an unrelated incident, which the 2026-08-17
+rollback rehearsal measured at seven minutes only because nothing else was in
+the way. A dependency audit fails for reasons that have nothing to do with the
+pull request in front of it.
+
+This is a change from the original arrangement, where the audit ran *only* at a
+release. A high-severity `nanoid` advisory consequently reached `production`
+through thirteen consecutive green CI runs and was found by hand on 2026-08-16.
+Visibility on every change was the gap; blocking every change was never the fix.
 
 Randi remains the only merge authority by project policy, even when GitHub
 requires zero external approvals.

--- a/docs/release-audit.md
+++ b/docs/release-audit.md
@@ -881,7 +881,7 @@ Two things follow for Randi, neither urgent, since there is nothing to rotate:
 | Q9 — project diagram schema field | Deferred. Listed as blocking implementation; implementation completed without it. Nothing to render until a diagram is sanitised (OPEN-006) |
 | Q10 — `remoteAvailability` rename | Deferred by v1.1 to v2, and by v2 to nothing. Twice-deferred is worth closing as a decision either way |
 | Home Lighthouse headroom | Median exactly 90 against a P1 floor of 90 |
-| `audit:prod` outside CI | The nanoid advisory survived thirteen green CI runs. Moving the audit into `quality`, or adding a scheduled run, would close it |
+| `audit:prod` outside CI | **Closed 2026-08-18.** A non-blocking `audit` job now runs on every pull request and push, and `security-audit.yml` sweeps daily so an advisory published during a quiet period is caught without waiting for a pull request. Deliberately *not* added to the required checks: an advisory published upstream overnight would otherwise block every merge, including the revert needed during an incident |
 | OPEN-003, OPEN-006, OPEN-007 | Third project, safe project visuals, custom domain — genuinely open |
 | `V2_HANDOFF_PRD.md` | Still untracked, pending Randi's decision on whether it is published |
 


### PR DESCRIPTION
Closes the last item from the v2 outstanding list: `audit:prod` ran only inside `release:check` and `release-audit.yml`, both manual.

A high-severity `nanoid` advisory therefore reached `production` through **thirteen consecutive green CI runs** and was found by hand at the v2 release gate on 2026-08-16.

## Two gaps, two triggers

| Where | When | Blocking |
|---|---|---|
| `ci.yml` job `audit` | every pull request and push | no |
| `security-audit.yml` | daily, 21:00 UTC (04:00 Asia/Jakarta) | no |

**The scheduled sweep is the one that matches what actually happened.** Nothing in this repository changed when the nanoid advisory appeared — it was published upstream against a lock file that had not moved. With v2 closed, weeks can pass without a pull request while the site stays publicly linked from job applications, and a per-change job would not run at all in that window.

## Deliberately not a required status check

This is the design decision worth your attention, and it goes against the obvious instinct.

Making `audit` required would mean an advisory published upstream overnight blocks **every** merge — including the revert you'd need to recover from an unrelated incident. The rollback rehearsal measured that path at seven minutes precisely because nothing stood in the way; a red required check that nobody caused and nobody can fix quickly would turn that into an unbounded wait.

A dependency audit fails for reasons that have nothing to do with the pull request in front of it. **Visibility on every change was the gap. Blocking every change was never the fix.**

It's also kept out of `quality` because `quality` and `e2e` are contractual with the branch ruleset *by exact job name* — this change adds a job and never touches those two.

Promote it to required later if you want, as a deliberate decision knowing the cost. `github-configuration.md` §4 now records the trade-off so that choice is made with the reasoning in front of you.

## Verified by breaking what it guards

Not synthetically — with the real defect. The exact command the new jobs run, against `package-lock.json` from `2ec9d00`, the tree that shipped nanoid 3.3.17 through thirteen green runs:

```
nanoid: custom generators can loop indefinitely when size is zero
1 high severity vulnerability
AUDIT EXIT: 1
```

So the job would have caught the advisory it exists for. On the current tree it reports `found 0 vulnerabilities` in **2.7s** — cheap enough to run everywhere without argument.

## Verification

```
npm run check   exit 0, 436 passed, 32 files
```

Both workflow files parse as valid YAML; `ci.yml` resolves to jobs `quality, e2e, audit` with `quality` and `e2e` unmodified. Prettier owns the workflow files and reports them clean. No source change, so no e2e run.

**One thing I got wrong and fixed:** my first attempt to update the audit record used `perl -0pi -e 's|...|...|'` on a markdown table row — the pipes are the substitution delimiter, so it prepended text at line 1 instead of replacing line 884. Caught it, reverted with `git checkout`, and redid it with a literal string replace that asserts the pattern is found exactly once. The file is back to 1077 lines with its heading intact.

**Confidentiality:** two workflow files and two docs. PRD absent from the commit (`0`).

**Deployment impact:** none. CI configuration only.

**Rollback notes:** a single `git revert`, at the measured ~7 minute cost.
