### PR TITLE
docs: correct the README after v2 and the audit job

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ review.
 
 **Live:** <https://developer-portfolio-delta-three.vercel.app/>
 
-**Status:** Production. Version 1 is deployed, indexed, and verified against
+**Status:** Production. Version 2 is deployed, indexed, and verified against
 [`docs/release-checklist.md`](docs/release-checklist.md) rather than inferred
 from a successful build. `npm run release:check` passes end to end: formatting,
 linting, strict type checking, content validation, unit and component tests, a
@@ -170,10 +170,16 @@ exercised against a deliberately violating fixture instead.
 
 ## CI/CD
 
-Pull requests to `production` run two required checks: `quality` (format, lint,
-typecheck, content validation, tests, build) and `e2e` (all three browser
-engines plus accessibility). The job names are matched by exact string in the
-branch ruleset, so renaming one silently detaches the required check.
+Pull requests to `production` run three jobs, two of which are required:
+`quality` (format, lint, typecheck, content validation, tests, build) and `e2e`
+(all three browser engines plus accessibility). The job names are matched by
+exact string in the branch ruleset, so renaming one silently detaches the
+required check.
+
+The third, `audit`, runs the production dependency audit and is deliberately
+**not** required. An advisory published upstream overnight would otherwise block
+every merge, including a revert needed during an unrelated incident. It reports
+on every change without holding the merge button hostage.
 
 `production` is the only long-lived branch. Work happens on short-lived task
 branches, merges by squash after review, and deploys automatically. Deployment
@@ -189,6 +195,11 @@ full gate on every push would be slow without being more informative. Running it
 end to end for the first time is what surfaced four defects — including a script
 declared in `package.json` that had never been written, and a workflow that had
 never once been dispatched.
+
+A separate scheduled workflow runs the dependency audit daily. A vulnerability
+is published on its author's timetable, not on the cadence of pull requests: a
+high-severity advisory once reached `production` through thirteen consecutive
+green CI runs, because at the time the audit ran only at a release.
 
 ---
 


### PR DESCRIPTION
Three claims in the README that stopped being true — on the file a recruiter opens first.

## 1. "Version 1 is deployed"

v2 shipped across thirteen pull requests and is live.

**This is v1.1 Issue 1 in a new form**, and the third instance this month after the v2.0 specification header ("Nothing here is implemented") and `src/content/media.ts` ("every asset here is Draft"). It keeps landing on public surfaces for the same structural reason: **a status line is the one part of a document nothing ever executes**, so nothing contradicts it. Prose describing behaviour eventually collides with the running site; a version number never does.

## 2. "Pull requests run two required checks"

Three jobs run now. Two are still the required ones, so the sentence wasn't false — but a reader would conclude only two exist.

The third, `audit`, is now described along with **why it is deliberately not required**: an advisory published upstream overnight would otherwise block every merge, including a revert needed during an unrelated incident. That reasoning now sits where someone would question the design rather than only in the governance doc.

## 3. "The release audit workflow is manual rather than automatic"

Still true of `release-audit.yml`, and now incomplete. `security-audit.yml` runs the dependency audit daily, because a vulnerability is published on its author's timetable rather than on the cadence of pull requests.

Not hypothetical: a high-severity advisory reached `production` through **thirteen consecutive green CI runs** while the audit ran only at a release.

## Every new claim verified against the system, not from memory

| Claim | Checked against |
|---|---|
| three jobs run | `ci.yml` → `quality, e2e, audit` |
| two are required | ruleset API → `quality, e2e` |
| a scheduled audit runs daily | `Security Audit` registered, `cron: "0 21 * * *"` |

The technology table was swept in the same pass and is accurate against `package.json`: Node 24, Next 16, React 19, TypeScript 6, Tailwind v4, Zod 4. No test counts are stated anywhere in current-state docs, so none could go stale.

## Verification

```
npm run check   exit 0, 436 passed, 32 files
```

Documentation only — no source change, so no e2e run. Merged-tree `release:check` on `f43dc5c` separately confirmed exit 0 before this branch was cut: 436 unit, 211 e2e, no broken links, `found 0 vulnerabilities`.

**Confidentiality:** one file, already public. PRD absent from the commit (`0`).

**Deployment impact:** none.

**Rollback notes:** single `git revert`, at the measured ~7 minute cost.
