### PR TITLE
test: gate the README's version claim against the release record

### DIFF
--- a/docs/product/PORTFOLIO_V2_ANALYSIS.md
+++ b/docs/product/PORTFOLIO_V2_ANALYSIS.md
@@ -1,9 +1,19 @@
 # Portfolio V2 Analysis
 
 **Document type:** V2 design analysis (PRD §76)
-**Status:** For review. No specification and no implementation code exists yet.
+**Status:** Superseded by delivery. Written 2026-08-12 as the pre-implementation
+analysis; v2 shipped across thirteen phase pull requests and closed on 2026-08-16.
+The specification it defers to is `PORTFOLIO_UX_UI_SPEC_v2.0.md`, and the outcome
+is the 2026-08-16 entry in `release-audit.md`.
 **Baseline commit:** `8b26b8a` on `production`
 **Date:** 2026-08-12
+
+> The header previously read *"For review. No specification and no implementation
+> code exists yet"* — true when written, false from the moment the specification
+> landed. Corrected 2026-08-25. Everything below is deliberately unchanged: the
+> body is a record of what was known on 2026-08-12, including seven conflicts and
+> a set of open questions, and rewriting it would destroy the thing it is for.
+> Only the status line made a claim about the present.
 
 This is the first of the two artifacts PRD §75 requires before any V2 code is
 written. It ends at a decision gate: §27 lists what needs Randi's answer, and the

--- a/docs/release-audit.md
+++ b/docs/release-audit.md
@@ -713,6 +713,22 @@ All four are corrected in this release, and the seven v2 design decisions are no
 DEC-049 through DEC-055 with their approval basis recorded — Randi's merge of the
 pull request that implemented each.
 
+**A fifth followed on 2026-08-23**: the README still announced "Version 1 is
+deployed" after v2 had shipped. **A sixth surfaced on 2026-08-25** while writing
+the gate for the other five — `PORTFOLIO_V2_ANALYSIS.md` still said "No
+specification and no implementation code exists yet". That one is the most
+instructive of the six: its companion, the v2.0 specification header, was
+corrected in this very release, and the sibling document was not checked in the
+same pass. Fixing an instance is not the same as fixing the class.
+
+Six instances, all found by reading, none by tooling — so the pattern is now
+gated. `tests/docs/status-accuracy.test.ts`
+asserts that the README's version claim matches the newest release on record,
+and fails rather than passing vacuously if either document is reworded so the
+pattern stops matching. It is deliberately narrow: it checks the one fact that
+went stale twice rather than trying to police prose, because a gate people learn
+to work around is worse than no gate.
+
 ### A stated process that was not followed, and should not have been
 
 The v2.0 specification instructed: *"Implementation PRs update citations in the files

--- a/tests/docs/status-accuracy.test.ts
+++ b/tests/docs/status-accuracy.test.ts
@@ -1,0 +1,85 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+/**
+ * The README's version claim must match the newest release on record.
+ *
+ * Five stale current-state claims were found by hand in August 2026: the v2.0
+ * specification header said "Nothing here is implemented" while all of it was
+ * live, src/content/media.ts said its assets were Draft files that did not
+ * exist while one was production's LCP element, the ledger listed four resolved
+ * decisions as open, layout.tsx named the wrong LCP element, and the README
+ * announced "Version 1 is deployed" after v2 had shipped.
+ *
+ * Every one was caught by reading. Nothing in a repository with 436 unit tests
+ * and 211 end-to-end tests was watching, because a status line is the one part
+ * of a document that nothing ever executes: prose describing behaviour is
+ * eventually contradicted by the running site, and a version number never is.
+ *
+ * This is deliberately narrow. It checks one fact that has now gone stale
+ * twice rather than trying to police prose, because a gate people learn to work
+ * around is worse than no gate.
+ */
+
+const ROOT = process.cwd();
+
+/** Headings look like: `## 2026-08-16 — v2 "Performance Engineering" release, closed` */
+const ENTRY = /^## (\d{4}-\d{2}-\d{2}) — (.+)$/gm;
+const VERSION_IN_TITLE = /\bv(\d+(?:\.\d+)?)\b/i;
+
+/** `**Status:** Production. Version 2 is deployed, indexed, and verified …` */
+const README_CLAIM = /\*\*Status:\*\*[^\n]*?\bVersion (\d+(?:\.\d+)?) is deployed\b/;
+
+interface ReleaseEntry {
+  readonly date: string;
+  readonly version: string;
+}
+
+/**
+ * The newest entry that *names* a release, which is not the same as the newest
+ * entry. The 2026-08-17 rollback rehearsal names no version, and treating it as
+ * the latest release would compare the README against nothing.
+ */
+function latestRecordedRelease(audit: string): ReleaseEntry | undefined {
+  const releases: ReleaseEntry[] = [];
+
+  for (const match of audit.matchAll(ENTRY)) {
+    const date = match[1];
+    const title = match[2];
+    if (date === undefined || title === undefined) continue;
+
+    const version = VERSION_IN_TITLE.exec(title)?.[1];
+    if (version !== undefined) releases.push({ date, version });
+  }
+
+  return releases.sort((a, b) => a.date.localeCompare(b.date)).at(-1);
+}
+
+describe("the README's status matches the release record", () => {
+  const readme = readFileSync(join(ROOT, "README.md"), "utf8");
+  const audit = readFileSync(join(ROOT, "docs/release-audit.md"), "utf8");
+
+  /*
+   * Both extractions are asserted before they are compared. If either document
+   * is reworded so the pattern stops matching, this test has to fail loudly
+   * rather than compare undefined to undefined and pass — which is exactly how
+   * two tests in this repository were green for an entire build while testing
+   * nothing.
+   */
+  it("finds a version claim in the README", () => {
+    expect(README_CLAIM.exec(readme)?.[1]).toBeDefined();
+  });
+
+  it("finds a release entry in the audit record", () => {
+    expect(latestRecordedRelease(audit)).toBeDefined();
+  });
+
+  it("states the version of the newest recorded release", () => {
+    const claimed = README_CLAIM.exec(readme)?.[1];
+    const recorded = latestRecordedRelease(audit);
+
+    expect(claimed).toBe(recorded?.version);
+  });
+});


### PR DESCRIPTION
Closes the last agreed item. Your decision, 2026-08-23: add a targeted test rather than broader documentation checks or nothing.

## The problem, stated as evidence

Six stale current-state claims found by hand this month:

| Document | Claimed | Reality |
|---|---|---|
| v2.0 spec header | "Nothing here is implemented" | all of it live |
| `src/content/media.ts` | assets are Draft, files don't exist | both published; one was production's LCP element |
| Decision Ledger | seven decisions open | four resolved eight months earlier |
| `src/app/layout.tsx` | hero `h1` is the LCP element | it's the photograph |
| `README.md` | "Version 1 is deployed" | v2 had shipped |
| `PORTFOLIO_V2_ANALYSIS.md` | "no implementation code exists yet" | thirteen phase PRs merged |

**All six found by reading. None by tooling** — in a repository with 436 unit tests and 211 end-to-end tests.

The reason is structural, not carelessness: **a status line is the one part of a document that nothing ever executes.** Prose describing behaviour eventually collides with the running site. A version number never does.

## The gate

`tests/docs/status-accuracy.test.ts` asserts the README's version claim matches the newest release named in `release-audit.md`.

The newest entry that **names** a release — which is not the newest entry. The 2026-08-17 rollback rehearsal names no version, and treating it as the latest release would compare the README against nothing.

Break-tested three ways:

| Break | Result |
|---|---|
| README claims Version 1 | `expected '1' to be '2'` |
| A v3 entry lands, README not updated | `expected '2' to be '3'` |
| README status line reworded | **the extraction assertion fails first** |

**That third property is the point.** Both extractions are asserted before they are compared, so a reworded document makes this fail loudly rather than compare `undefined` to `undefined` and pass. Two tests in this repository were once green for an entire build while testing nothing.

Deliberately narrow — it checks the one fact that went stale twice rather than trying to police prose, because a gate people learn to work around is worse than no gate.

## It found a sixth instance before it shipped — and that one is mine

While grepping for other version claims, `PORTFOLIO_V2_ANALYSIS.md` still said *"No specification and no implementation code exists yet."*

Its companion — the v2.0 specification header — **was corrected in PR #60, and I never checked the sibling document in the same pass.** Fixing an instance is not the same as fixing the class. That's now on the record alongside the correction.

Only its status line changed. The body is deliberately untouched: it records what was known on 2026-08-12, seven conflicts and open questions included, and rewriting it would destroy what it's for.

## Verification

```
npm run check      exit 0, 439 passed in 33 files  (was 436 in 32)
npm run test:e2e   exit 0, 211 passed, 2 skipped, three engines
```

**The first e2e run exited 1** with 209 passed. Both failures were Firefox crashing at the graphics layer — `RenderCompositorSWGL failed mapping default framebuffer`, then `AbnormalShutdown` and context timeouts — rather than any assertion. Re-run unchanged: 211 passed, **zero crash markers**. Recorded here rather than quietly re-run into a green number.

**Confidentiality:** one test, two documents. PRD absent from the commit (`0`).

**Deployment impact:** none. No source change.

**Rollback notes:** single `git revert`, ~7 minutes.

---

⚠️ **Still outstanding and outside the repository: production's canonical URL.**

`developer-portfolio-delta-three.vercel.app` returns 404; the site lives at `randi-fajar-wicaksono.vercel.app` but declares the dead URL as its canonical, `og:url`, and in every sitemap entry. That's `SITE_URL` in Vercel's production environment.

Worth noting against this PR: **this gate would not have caught that**, and neither would `check:links`, which never tests the site's own address. A check that the deployed site answers at its declared `SITE_URL` is the one that would.
